### PR TITLE
Add observability middleware, seeding script, and CI docker build

### DIFF
--- a/sais/.env.example
+++ b/sais/.env.example
@@ -1,0 +1,19 @@
+# Core infrastructure
+POSTGRES_DB=sais
+POSTGRES_USER=sais
+POSTGRES_PASSWORD=sais
+DATABASE_URL=postgresql+psycopg2://sais:sais@db:5432/sais
+REDIS_URL=redis://redis:6379/0
+TZ=America/Fortaleza
+CORS_ORIGINS=["http://localhost:3000","http://localhost:3001"]
+RATE_LIMIT_REQUESTS=120
+RATE_LIMIT_WINDOW_SECONDS=60
+
+# Evolution WhatsApp API integration
+EVOLUTION_API_BASE_URL=http://localhost:8080
+EVOLUTION_INSTANCE_NAME=your-instance
+EVOLUTION_API_KEY=change-me
+WEBHOOK_VERIFY_TOKEN=verify-me
+WHATSAPP_MOCK_MODE=true
+WHATSAPP_DEFAULT_TENANT_NAME=Default WhatsApp Tenant
+# WHATSAPP_DEFAULT_TENANT_ID=00000000-0000-0000-0000-000000000000

--- a/sais/.github/workflows/ci.yml
+++ b/sais/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  api:
+    name: API checks
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sais/api
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Validate sources
+        run: python -m compileall app
+      - name: Run tests
+        run: pytest
+
+  web:
+    name: Web lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sais/web
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint -- --no-color
+
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sais
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build API image
+        run: docker build -f ops/docker/api.Dockerfile -t sais-api-ci .
+      - name: Build web image
+        run: docker build -f ops/docker/web.Dockerfile -t sais-web-ci .
+      - name: Build worker image
+        run: docker build -f ops/docker/worker.Dockerfile -t sais-worker-ci .
+      - name: Validate docker compose configuration
+        run: docker compose -f docker-compose.yml config -q

--- a/sais/.gitignore
+++ b/sais/.gitignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.py[cod]
+*.sqlite3
+.env
+.env.local
+.env.*
+!.env.example
+.venv/
+node_modules/
+.next/
+.DS_Store
+.idea/
+.vscode/
+dist/
+build/

--- a/sais/Makefile
+++ b/sais/Makefile
@@ -1,0 +1,2 @@
+COMPOSE_FILE ?= docker-compose.yml
+include ops/Makefile

--- a/sais/api/alembic.ini
+++ b/sais/api/alembic.ini
@@ -1,0 +1,39 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+
+sqlalchemy.url = postgresql+psycopg2://sais:sais@db:5432/sais
+
+dispatcher = logging
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/sais/api/alembic/env.py
+++ b/sais/api/alembic/env.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+import sys
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import create_engine, pool
+
+CURRENT_DIR = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT_DIR, ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.append(PROJECT_ROOT)
+
+from app.core.config import settings  # noqa: E402
+from app.db.base import Base  # noqa: E402
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def get_database_url() -> str:
+    return settings.database_url
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = get_database_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    connectable = create_engine(get_database_url(), poolclass=pool.NullPool)
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/sais/api/alembic/script.py.mako
+++ b/sais/api/alembic/script.py.mako
@@ -1,0 +1,18 @@
+"""${message}"""
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/sais/api/alembic/versions/20240418001_initial.py
+++ b/sais/api/alembic/versions/20240418001_initial.py
@@ -1,0 +1,165 @@
+"""Initial SAIS schema."""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20240418001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tenants",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column(
+            "timezone",
+            sa.String(length=64),
+            nullable=False,
+            server_default=sa.text("'America/Fortaleza'"),
+        ),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.UniqueConstraint("name", name="uq_tenants_name"),
+    )
+
+    op.create_table(
+        "patients",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("full_name", sa.String(length=255), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=True),
+        sa.Column("phone_number", sa.String(length=32), nullable=True),
+        sa.Column("date_of_birth", sa.Date(), nullable=True),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_patients_tenant_id", "patients", ["tenant_id"], unique=False)
+
+    op.create_table(
+        "providers",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("full_name", sa.String(length=255), nullable=False),
+        sa.Column("specialty", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_providers_tenant_id", "providers", ["tenant_id"], unique=False)
+
+    op.create_table(
+        "services",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("duration_minutes", sa.Integer(), nullable=False, server_default=sa.text("30")),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_services_tenant_id", "services", ["tenant_id"], unique=False)
+
+    op.create_table(
+        "schedule_slots",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("provider_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("service_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("start_time", sa.DateTime(), nullable=False),
+        sa.Column("end_time", sa.DateTime(), nullable=False),
+        sa.Column("is_booked", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["provider_id"], ["providers.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["service_id"], ["services.id"], ondelete="SET NULL"),
+    )
+    op.create_index("ix_schedule_slots_tenant_id", "schedule_slots", ["tenant_id"], unique=False)
+    op.create_index(
+        "ix_schedule_slots_provider_id", "schedule_slots", ["provider_id"], unique=False
+    )
+
+    op.create_table(
+        "appointments",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("patient_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("provider_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("service_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("schedule_slot_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False, server_default=sa.text("'scheduled'")),
+        sa.Column("scheduled_start", sa.DateTime(), nullable=True),
+        sa.Column("scheduled_end", sa.DateTime(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["patient_id"], ["patients.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["provider_id"], ["providers.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["service_id"], ["services.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["schedule_slot_id"], ["schedule_slots.id"], ondelete="SET NULL"),
+    )
+    op.create_index("ix_appointments_tenant_id", "appointments", ["tenant_id"], unique=False)
+    op.create_index("ix_appointments_patient_id", "appointments", ["patient_id"], unique=False)
+    op.create_index("ix_appointments_provider_id", "appointments", ["provider_id"], unique=False)
+
+    op.create_table(
+        "message_logs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("appointment_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("channel", sa.String(length=32), nullable=False),
+        sa.Column("recipient", sa.String(length=255), nullable=True),
+        sa.Column("payload", sa.Text(), nullable=True),
+        sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False, server_default=sa.text("'pending'")),
+        sa.Column("sent_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["appointment_id"], ["appointments.id"], ondelete="SET NULL"),
+    )
+    op.create_index("ix_message_logs_tenant_id", "message_logs", ["tenant_id"], unique=False)
+
+    op.create_table(
+        "audit_logs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("actor", sa.String(length=255), nullable=True),
+        sa.Column("action", sa.String(length=255), nullable=False),
+        sa.Column("resource", sa.String(length=255), nullable=True),
+        sa.Column("occurred_at", sa.DateTime(), nullable=False),
+        sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_audit_logs_tenant_id", "audit_logs", ["tenant_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_audit_logs_tenant_id", table_name="audit_logs")
+    op.drop_table("audit_logs")
+    op.drop_index("ix_message_logs_tenant_id", table_name="message_logs")
+    op.drop_table("message_logs")
+    op.drop_index("ix_appointments_provider_id", table_name="appointments")
+    op.drop_index("ix_appointments_patient_id", table_name="appointments")
+    op.drop_index("ix_appointments_tenant_id", table_name="appointments")
+    op.drop_table("appointments")
+    op.drop_index("ix_schedule_slots_provider_id", table_name="schedule_slots")
+    op.drop_index("ix_schedule_slots_tenant_id", table_name="schedule_slots")
+    op.drop_table("schedule_slots")
+    op.drop_index("ix_services_tenant_id", table_name="services")
+    op.drop_table("services")
+    op.drop_index("ix_providers_tenant_id", table_name="providers")
+    op.drop_table("providers")
+    op.drop_index("ix_patients_tenant_id", table_name="patients")
+    op.drop_table("patients")
+    op.drop_table("tenants")

--- a/sais/api/alembic/versions/20240418002_schedule_rules.py
+++ b/sais/api/alembic/versions/20240418002_schedule_rules.py
@@ -1,0 +1,125 @@
+"""Add scheduling rules and appointment metadata."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20240418002"
+down_revision = "20240418001_initial"
+branch_labels = None
+depends_on = None
+
+
+slot_status_enum = postgresql.ENUM(
+    "FREE", "HOLD", "BOOKED", "BLOCKED", name="schedule_slot_status"
+)
+appointment_status_enum = postgresql.ENUM(
+    "CONFIRMED", "RESCHEDULED", "CANCELLED", "NO_SHOW", "COMPLETED",
+    name="appointment_status",
+)
+appointment_origin_enum = postgresql.ENUM(
+    "WHATSAPP", "WEB", "STAFF", name="appointment_origin"
+)
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "services",
+        "duration_minutes",
+        new_column_name="duration_min",
+        existing_type=sa.Integer(),
+        existing_nullable=False,
+    )
+    op.add_column(
+        "services",
+        sa.Column("price_cents", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.alter_column("services", "price_cents", server_default=None)
+
+    slot_status_enum.create(op.get_bind(), checkfirst=True)
+    op.add_column(
+        "schedule_slots",
+        sa.Column(
+            "status",
+            slot_status_enum,
+            nullable=False,
+            server_default="FREE",
+        ),
+    )
+    op.add_column(
+        "schedule_slots",
+        sa.Column("hold_expires_at", sa.DateTime(), nullable=True),
+    )
+    op.execute(
+        "UPDATE schedule_slots SET status = 'BOOKED' WHERE is_booked = true"
+    )
+    op.drop_column("schedule_slots", "is_booked")
+    op.alter_column("schedule_slots", "status", server_default=None)
+
+    appointment_status_enum.create(op.get_bind(), checkfirst=True)
+    appointment_origin_enum.create(op.get_bind(), checkfirst=True)
+    op.execute(
+        "UPDATE appointments SET status = 'CONFIRMED' WHERE status IS NULL OR status = 'scheduled'"
+    )
+    op.alter_column(
+        "appointments",
+        "status",
+        type_=appointment_status_enum,
+        existing_type=sa.String(length=32),
+        postgresql_using="status::text::appointment_status",
+        existing_nullable=False,
+        server_default="CONFIRMED",
+    )
+    op.add_column(
+        "appointments",
+        sa.Column(
+            "origin",
+            appointment_origin_enum,
+            nullable=False,
+            server_default="WHATSAPP",
+        ),
+    )
+    op.alter_column("appointments", "origin", server_default=None)
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "appointments",
+        "status",
+        type_=sa.String(length=32),
+        existing_type=appointment_status_enum,
+        server_default="scheduled",
+        postgresql_using="status::text",
+        existing_nullable=False,
+    )
+    op.drop_column("appointments", "origin")
+    appointment_origin_enum.drop(op.get_bind(), checkfirst=True)
+    appointment_status_enum.drop(op.get_bind(), checkfirst=True)
+
+    op.add_column(
+        "schedule_slots",
+        sa.Column(
+            "is_booked",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+    )
+    op.execute(
+        "UPDATE schedule_slots SET is_booked = true WHERE status IN ('BOOKED', 'BLOCKED')"
+    )
+    op.drop_column("schedule_slots", "hold_expires_at")
+    op.drop_column("schedule_slots", "status")
+    slot_status_enum.drop(op.get_bind(), checkfirst=True)
+
+    op.drop_column("services", "price_cents")
+    op.alter_column(
+        "services",
+        "duration_min",
+        new_column_name="duration_minutes",
+        existing_type=sa.Integer(),
+        existing_nullable=False,
+    )

--- a/sais/api/app/__init__.py
+++ b/sais/api/app/__init__.py
@@ -1,0 +1,3 @@
+"""SAIS API package initialization."""
+
+__all__ = ["main"]

--- a/sais/api/app/core/config.py
+++ b/sais/api/app/core/config.py
@@ -1,0 +1,37 @@
+from functools import lru_cache
+from uuid import UUID
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    app_name: str = "SAIS API"
+    database_url: str = (
+        "postgresql+psycopg2://sais:sais@db:5432/sais"  # pragma: allowlist secret
+    )
+    redis_url: str = "redis://redis:6379/0"
+    timezone: str = "America/Fortaleza"
+    cors_origins: list[str] = ["http://localhost:3000"]
+    rate_limit_requests: int = 120
+    rate_limit_window_seconds: int = 60
+    evolution_api_base_url: str = "http://localhost:8080"
+    evolution_instance_name: str = ""
+    evolution_api_key: str = ""
+    webhook_verify_token: str = ""
+    whatsapp_mock_mode: bool = False
+    whatsapp_default_tenant_id: UUID | None = None
+    whatsapp_default_tenant_name: str = "Default WhatsApp Tenant"
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return a cached settings instance."""
+
+    return Settings()
+
+
+settings = get_settings()

--- a/sais/api/app/db/base.py
+++ b/sais/api/app/db/base.py
@@ -1,0 +1,25 @@
+"""Import SQLAlchemy models for Alembic's autogenerate feature."""
+
+from app.models.base import Base
+from app.models import (  # noqa: F401
+    Appointment,
+    AuditLog,
+    MessageLog,
+    Patient,
+    Provider,
+    ScheduleSlot,
+    Service,
+    Tenant,
+)
+
+__all__ = [
+    "Base",
+    "Appointment",
+    "AuditLog",
+    "MessageLog",
+    "Patient",
+    "Provider",
+    "ScheduleSlot",
+    "Service",
+    "Tenant",
+]

--- a/sais/api/app/db/session.py
+++ b/sais/api/app/db/session.py
@@ -1,0 +1,23 @@
+from collections.abc import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.core.config import settings
+
+engine = create_engine(settings.database_url, future=True)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
+
+
+def get_db() -> Generator[Session, None, None]:
+    """Provide a transactional scope around a series of operations."""
+
+    db = SessionLocal()
+    try:
+        yield db
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()

--- a/sais/api/app/logging_utils.py
+++ b/sais/api/app/logging_utils.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import sys
+from typing import Any
+from uuid import UUID
+
+_request_id_ctx_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "request_id", default=None
+)
+_tenant_id_ctx_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "tenant_id", default=None
+)
+
+
+class RequestContextFilter(logging.Filter):
+    """Inject request scoped context variables into log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - simple
+        record.request_id = _request_id_ctx_var.get()
+        record.tenant_id = _tenant_id_ctx_var.get()
+        return True
+
+
+class JSONLogFormatter(logging.Formatter):
+    """Serialize log records as JSON with context metadata."""
+
+    def __init__(self) -> None:  # pragma: no cover - trivial
+        super().__init__(datefmt="%Y-%m-%dT%H:%M:%S%z")
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_entry: dict[str, Any] = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "request_id": record.__dict__.get("request_id"),
+            "tenant_id": record.__dict__.get("tenant_id"),
+        }
+
+        standard_attributes = {
+            "name",
+            "msg",
+            "args",
+            "levelname",
+            "levelno",
+            "pathname",
+            "filename",
+            "module",
+            "exc_info",
+            "exc_text",
+            "stack_info",
+            "lineno",
+            "funcName",
+            "created",
+            "msecs",
+            "relativeCreated",
+            "thread",
+            "threadName",
+            "processName",
+            "process",
+            "message",
+        }
+
+        for key, value in record.__dict__.items():
+            if key in ("request_id", "tenant_id"):
+                continue
+            if key.startswith("_") or key in standard_attributes:
+                continue
+            log_entry[key] = value
+
+        if record.exc_info:
+            log_entry["exc_info"] = self.formatException(record.exc_info)
+
+        return json.dumps(log_entry, ensure_ascii=False)
+
+
+_configured = False
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure the root logger for structured JSON output."""
+
+    global _configured
+    if _configured:  # pragma: no cover - defensive
+        return
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JSONLogFormatter())
+    handler.addFilter(RequestContextFilter())
+
+    root_logger = logging.getLogger()
+    root_logger.handlers = []
+    root_logger.setLevel(level)
+    root_logger.addHandler(handler)
+
+    for logger_name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+        logger = logging.getLogger(logger_name)
+        logger.handlers = []
+        logger.propagate = True
+
+    _configured = True
+
+
+def set_tenant_context(tenant_id: UUID | str | None) -> None:
+    """Bind the tenant identifier to the current logging context."""
+
+    if tenant_id is None:
+        _tenant_id_ctx_var.set(None)
+    elif isinstance(tenant_id, UUID):
+        _tenant_id_ctx_var.set(str(tenant_id))
+    else:
+        _tenant_id_ctx_var.set(tenant_id)
+
+
+def get_current_tenant() -> str:
+    """Return the tenant id bound to the current context."""
+
+    tenant = _tenant_id_ctx_var.get()
+    return tenant or "anonymous"
+
+
+def get_request_id() -> str:
+    """Return the request id bound to the current context."""
+
+    request_id = _request_id_ctx_var.get()
+    return request_id or "unknown"
+
+
+__all__ = [
+    "configure_logging",
+    "get_current_tenant",
+    "get_request_id",
+    "set_tenant_context",
+    "_request_id_ctx_var",
+    "_tenant_id_ctx_var",
+]

--- a/sais/api/app/main.py
+++ b/sais/api/app/main.py
@@ -1,0 +1,1428 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Sequence
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, status
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, PlainTextResponse, Response
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.core.config import settings
+from app.db.session import get_db
+from app.models import (
+    Appointment,
+    AppointmentOrigin,
+    AppointmentStatus,
+    MessageLog,
+    Patient,
+    Provider,
+    ScheduleSlot,
+    Service,
+    SlotStatus,
+    Tenant,
+)
+from app.services import (
+    BotState,
+    clear_context,
+    get_context,
+    get_state,
+    record_last_interaction,
+    send_interactive_buttons,
+    send_template,
+    send_text,
+    set_context,
+    set_state,
+)
+from app.services.bot_state import last_interaction_within
+from app.services.scheduling import (
+    book_slot,
+    ensure_utc,
+    get_slot_by_start,
+    offer_slots,
+    serialize_appointment,
+    tenant_timezone,
+)
+from app.logging_utils import (
+    configure_logging,
+    get_current_tenant,
+    get_request_id,
+    set_tenant_context,
+    _request_id_ctx_var,
+    _tenant_id_ctx_var,
+)
+
+configure_logging()
+
+app = FastAPI(title=settings.app_name, version="0.1.0")
+
+logger = logging.getLogger(__name__)
+
+WHATSAPP_SESSION_WINDOW = timedelta(hours=24)
+MENU_PROMPT = "Como podemos ajudar? Escolha uma opção para continuar:"
+MENU_BUTTONS = ["Agendar", "Reagendar", "Falar com atendente"]
+
+REQUEST_COUNTER = Counter(
+    "sais_api_requests_total",
+    "Total number of processed HTTP requests.",
+    ["method", "path", "status", "tenant"],
+)
+REQUEST_LATENCY = Histogram(
+    "sais_api_request_duration_seconds",
+    "HTTP request latency in seconds.",
+    ["method", "path"],
+)
+
+
+class SimpleRateLimiter:
+    """In-memory rate limiter keyed by IP and tenant."""
+
+    def __init__(self, limit: int, window_seconds: int) -> None:
+        self.limit = max(1, limit)
+        self.window_seconds = max(1, window_seconds)
+        self._entries: dict[str, tuple[int, float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def allow(self, key: str) -> bool:
+        now = time.monotonic()
+        async with self._lock:
+            count, window_start = self._entries.get(key, (0, now))
+            if now - window_start >= self.window_seconds:
+                self._entries[key] = (1, now)
+                return True
+            if count >= self.limit:
+                return False
+            self._entries[key] = (count + 1, window_start)
+            return True
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    """Populate request and tenant context for logging."""
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+        tenant_hint = request.headers.get("X-Tenant-ID")
+
+        request.state.request_id = request_id
+        request_id_token = _request_id_ctx_var.set(request_id)
+        tenant_token = _tenant_id_ctx_var.set(tenant_hint)
+
+        try:
+            response = await call_next(request)
+        finally:
+            _request_id_ctx_var.reset(request_id_token)
+            _tenant_id_ctx_var.reset(tenant_token)
+
+        response.headers["X-Request-ID"] = request_id
+        return response
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Apply a coarse rate limit per IP and tenant."""
+
+    def __init__(self, app: FastAPI, limiter: SimpleRateLimiter) -> None:  # type: ignore[override]
+        super().__init__(app)
+        self.limiter = limiter
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        if request.method == "OPTIONS":
+            return await call_next(request)
+
+        client_host = request.client.host if request.client else "unknown"
+        tenant_key = _tenant_id_ctx_var.get() or request.headers.get("X-Tenant-ID")
+        tenant_value = tenant_key or "anonymous"
+        rate_key = f"{client_host}:{tenant_value}"
+
+        allowed = await self.limiter.allow(rate_key)
+        if not allowed:
+            logger.warning(
+                "rate limit exceeded",
+                extra={"client_ip": client_host, "tenant": tenant_value},
+            )
+            return JSONResponse(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                content={"detail": "Rate limit exceeded"},
+            )
+
+        return await call_next(request)
+
+
+class AccessLogMiddleware(BaseHTTPMiddleware):
+    """Emit structured access logs and feed metrics."""
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        start_time = time.perf_counter()
+        path = request.scope.get("root_path", "") + request.scope.get("path", request.url.path)
+        method = request.method
+
+        try:
+            response = await call_next(request)
+        except Exception:
+            elapsed = time.perf_counter() - start_time
+            tenant_label = get_current_tenant()
+            REQUEST_COUNTER.labels(method=method, path=path, status="500", tenant=tenant_label).inc()
+            REQUEST_LATENCY.labels(method=method, path=path).observe(elapsed)
+            logger.exception(
+                "request failed",
+                extra={
+                    "method": method,
+                    "path": path,
+                    "duration_ms": round(elapsed * 1000, 2),
+                },
+            )
+            raise
+
+        elapsed = time.perf_counter() - start_time
+        status_code = response.status_code
+        tenant_label = get_current_tenant()
+
+        REQUEST_COUNTER.labels(
+            method=method,
+            path=path,
+            status=str(status_code),
+            tenant=tenant_label,
+        ).inc()
+        REQUEST_LATENCY.labels(method=method, path=path).observe(elapsed)
+
+        logger.info(
+            "request completed",
+            extra={
+                "method": method,
+                "path": path,
+                "status_code": status_code,
+                "duration_ms": round(elapsed * 1000, 2),
+            },
+        )
+
+        return response
+
+
+rate_limiter = SimpleRateLimiter(
+    settings.rate_limit_requests, settings.rate_limit_window_seconds
+)
+
+
+app.add_middleware(RequestContextMiddleware)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+app.add_middleware(RateLimitMiddleware, limiter=rate_limiter)
+app.add_middleware(AccessLogMiddleware)
+
+
+class AppointmentCreate(BaseModel):
+    patient_id: UUID
+    provider_id: UUID
+    service_id: UUID
+    start_ts: datetime
+    origin: AppointmentOrigin = AppointmentOrigin.WEB
+    notes: str | None = None
+    schedule_slot_id: UUID | None = None
+
+
+class AppointmentUpdate(BaseModel):
+    status: AppointmentStatus
+    notes: str | None = None
+
+
+def ensure_default_tenant(db: Session) -> UUID:
+    """Return a tenant identifier, creating a placeholder if required."""
+
+    tenant_id = settings.whatsapp_default_tenant_id
+    if tenant_id:
+        tenant = db.get(Tenant, tenant_id)
+        if tenant:
+            set_tenant_context(tenant.id)
+            return tenant.id
+        tenant = Tenant(
+            id=tenant_id,
+            name=settings.whatsapp_default_tenant_name,
+            timezone=settings.timezone,
+        )
+        db.add(tenant)
+        db.flush()
+        logger.debug("Created default tenant %s for WhatsApp logs", tenant_id)
+        set_tenant_context(tenant.id)
+        return tenant.id
+
+    tenant = db.execute(select(Tenant).limit(1)).scalar_one_or_none()
+    if tenant:
+        set_tenant_context(tenant.id)
+        return tenant.id
+
+    placeholder = Tenant(
+        name=settings.whatsapp_default_tenant_name,
+        timezone=settings.timezone,
+    )
+    db.add(placeholder)
+    db.flush()
+    logger.debug(
+        "Created placeholder tenant %s for WhatsApp logs", placeholder.id
+    )
+    set_tenant_context(placeholder.id)
+    return placeholder.id
+
+
+def persist_message_log(
+    db: Session,
+    *,
+    tenant_id: UUID,
+    channel: str,
+    recipient: str | None,
+    payload: Any,
+    metadata: dict[str, Any] | None,
+    status: str,
+    sent_at: datetime | None,
+) -> MessageLog:
+    """Persist a record in the message log table."""
+
+    set_tenant_context(tenant_id)
+
+    payload_value = (
+        payload
+        if isinstance(payload, str)
+        else json.dumps(payload, ensure_ascii=False, default=str)
+    )
+
+    log_entry = MessageLog(
+        tenant_id=tenant_id,
+        channel=channel,
+        recipient=recipient,
+        payload=payload_value,
+        metadata_json=metadata,
+        status=status,
+        sent_at=sent_at,
+    )
+    db.add(log_entry)
+    db.flush()
+    return log_entry
+
+
+def log_outbound_message(
+    db: Session,
+    *,
+    tenant_id: UUID,
+    phone: str,
+    request_payload: Any,
+    response_payload: Any,
+    response_type: str,
+    session_active: bool,
+    metadata_extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Persist an outbound message in the log and return response metadata."""
+
+    set_tenant_context(tenant_id)
+
+    message_id = None
+    if isinstance(response_payload, dict):
+        message_id = (
+            response_payload.get("key", {}).get("id")
+            or response_payload.get("id")
+            or response_payload.get("message", {}).get("key", {}).get("id")
+        )
+
+    metadata = {
+        "direction": "outbound",
+        "type": response_type,
+        "session_active": session_active,
+        "integration": "evolution_api",
+    }
+    if message_id:
+        metadata["wa_message_id"] = message_id
+    if metadata_extra:
+        metadata.update(metadata_extra)
+
+    now = datetime.now(timezone.utc)
+    persist_message_log(
+        db,
+        tenant_id=tenant_id,
+        channel="whatsapp",
+        recipient=phone,
+        payload={"request": request_payload, "response": response_payload},
+        metadata=metadata,
+        status="sent",
+        sent_at=now,
+    )
+    record_last_interaction(phone, now)
+    return {
+        "message_id": message_id,
+        "type": response_type,
+        "session_active": session_active,
+    }
+
+
+def parse_timestamp(raw_timestamp: str | None) -> datetime:
+    """Convert WhatsApp timestamps (seconds since epoch) to timezone-aware datetimes."""
+
+    if not raw_timestamp:
+        return datetime.now(timezone.utc)
+    try:
+        return datetime.fromtimestamp(int(raw_timestamp), tz=timezone.utc)
+    except (TypeError, ValueError):
+        logger.debug("Invalid timestamp payload received: %s", raw_timestamp)
+        return datetime.now(timezone.utc)
+
+
+def jid_to_phone(jid: str | None) -> str | None:
+    """Extract the numeric portion of a WhatsApp JID."""
+
+    if not jid:
+        return None
+    phone = jid.split("@", 1)[0]
+    digits = re.sub(r"\D", "", phone)
+    return digits or None
+
+
+def ensure_patient_profile(
+    db: Session, *, tenant_id: UUID, phone_number: str, display_name: str | None
+) -> Patient:
+    """Return a patient for the phone number, creating a placeholder if needed."""
+
+    stmt = select(Patient).where(
+        Patient.tenant_id == tenant_id, Patient.phone_number == phone_number
+    )
+    patient = db.execute(stmt).scalars().first()
+    if patient:
+        return patient
+
+    placeholder_name = display_name or f"Paciente {phone_number[-4:]}"
+    patient = Patient(
+        tenant_id=tenant_id,
+        full_name=placeholder_name,
+        phone_number=phone_number,
+    )
+    db.add(patient)
+    db.flush()
+    return patient
+
+
+def service_options(db: Session, tenant_id: UUID) -> list[dict[str, Any]]:
+    """Fetch the available services for the tenant."""
+
+    stmt = select(Service).where(Service.tenant_id == tenant_id).order_by(Service.name)
+    services = db.execute(stmt).scalars().all()
+    return [
+        {
+            "id": str(service.id),
+            "name": service.name,
+            "duration_min": service.duration_min,
+            "price_cents": service.price_cents,
+        }
+        for service in services
+    ]
+
+
+def primary_provider(db: Session, tenant_id: UUID) -> Provider | None:
+    """Return the first provider for a tenant to drive the WhatsApp flow."""
+
+    stmt = (
+        select(Provider)
+        .where(Provider.tenant_id == tenant_id)
+        .order_by(Provider.full_name)
+        .limit(1)
+    )
+    return db.execute(stmt).scalars().first()
+
+
+def parse_service_choice(
+    user_input: str, options: Sequence[dict[str, Any]]
+) -> dict[str, Any] | None:
+    """Resolve the service based on numeric or textual input."""
+
+    normalized = user_input.strip().casefold()
+    if normalized.isdigit():
+        index = int(normalized) - 1
+        if 0 <= index < len(options):
+            return options[index]
+
+    for option in options:
+        if option["name"].casefold() == normalized:
+            return option
+        if option["id"].casefold() == normalized:
+            return option
+    return None
+
+
+def parse_date_choice(user_input: str) -> date | None:
+    """Parse a YYYY-MM-DD formatted date."""
+
+    try:
+        return datetime.strptime(user_input.strip(), "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def format_service_prompt(options: Sequence[dict[str, Any]]) -> str:
+    """Generate the text prompt listing services."""
+
+    if not options:
+        return "No momento não encontramos serviços disponíveis."
+
+    lines = [
+        "Perfeito! Escolha um serviço digitando o número correspondente:",
+    ]
+    for index, option in enumerate(options, start=1):
+        lines.append(
+            f"{index}. {option['name']} ({option['duration_min']} min)"
+        )
+    return "\n".join(lines)
+
+
+def format_slot_prompt(
+    *,
+    slots: Sequence[dict[str, Any]],
+    target_date: date,
+    tz: ZoneInfo,
+    service_name: str,
+) -> str:
+    """Generate a textual prompt listing available slots."""
+
+    if not slots:
+        return (
+            f"Não encontramos horários disponíveis para {service_name} em {target_date.isoformat()}."
+            "\nEnvie outra data no formato YYYY-MM-DD para tentar novamente."
+        )
+
+    lines = [
+        f"Horários disponíveis em {target_date.strftime('%d/%m/%Y')} para {service_name}:",
+    ]
+    for index, option in enumerate(slots, start=1):
+        start_local = datetime.fromisoformat(option["start_local"]).astimezone(tz)
+        lines.append(f"{index}. {start_local.strftime('%H:%M')}")
+    lines.append("Responda com o número ou horário desejado (HH:MM).")
+    return "\n".join(lines)
+
+
+def parse_slot_choice(
+    user_input: str, options: Sequence[dict[str, Any]], tz: ZoneInfo
+) -> dict[str, Any] | None:
+    """Select a slot based on numeric index or HH:MM time."""
+
+    normalized = user_input.strip()
+    if normalized.isdigit():
+        index = int(normalized) - 1
+        if 0 <= index < len(options):
+            return options[index]
+
+    try:
+        requested_time = datetime.strptime(normalized, "%H:%M").time()
+    except ValueError:
+        return None
+
+    for option in options:
+        start_local = datetime.fromisoformat(option["start_local"]).astimezone(tz)
+        if (
+            start_local.hour == requested_time.hour
+            and start_local.minute == requested_time.minute
+        ):
+            return option
+    return None
+
+
+def lock_slot_by_id(db: Session, slot_id: UUID) -> ScheduleSlot | None:
+    """Fetch a slot by identifier with row-level locking."""
+
+    stmt = select(ScheduleSlot).where(ScheduleSlot.id == slot_id).with_for_update()
+    return db.execute(stmt).scalars().first()
+
+
+def to_utc_from_tenant(dt_value: datetime, tenant: Tenant) -> datetime:
+    """Convert an arbitrary datetime to UTC assuming tenant timezone when naive."""
+
+    tz = tenant_timezone(tenant)
+    if dt_value.tzinfo is None:
+        localized = dt_value.replace(tzinfo=tz)
+    else:
+        localized = dt_value.astimezone(tz)
+    return localized.astimezone(timezone.utc)
+
+def normalize_evolution_message(
+    raw_message: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Convert Evolution webhook payloads into a Graph-like message structure."""
+
+    key = raw_message.get("key", {}) or {}
+    message_body = raw_message.get("message", {}) or {}
+    message_type = raw_message.get("messageType")
+    remote_jid = key.get("remoteJid") or ""
+    message_id = key.get("id") or raw_message.get("id")
+
+    timestamp = raw_message.get("messageTimestamp")
+    if timestamp is None:
+        normalized_timestamp = datetime.now(timezone.utc)
+    else:
+        try:
+            normalized_timestamp = datetime.fromtimestamp(
+                int(timestamp), tz=timezone.utc
+            )
+        except (TypeError, ValueError):
+            normalized_timestamp = datetime.now(timezone.utc)
+
+    normalized_message: dict[str, Any] = {
+        "id": message_id,
+        "from": jid_to_phone(remote_jid),
+        "timestamp": str(int(normalized_timestamp.timestamp())),
+        "type": "text",
+    }
+
+    if "conversation" in message_body:
+        normalized_message["type"] = "text"
+        normalized_message["text"] = {"body": message_body.get("conversation", "")}
+    elif "extendedTextMessage" in message_body:
+        text_body = message_body.get("extendedTextMessage", {}).get("text", "")
+        normalized_message["type"] = "text"
+        normalized_message["text"] = {"body": text_body}
+    elif "imageMessage" in message_body:
+        normalized_message["type"] = "image"
+        normalized_message["image"] = message_body.get("imageMessage", {})
+    elif "videoMessage" in message_body:
+        normalized_message["type"] = "video"
+        normalized_message["video"] = message_body.get("videoMessage", {})
+    elif "audioMessage" in message_body:
+        normalized_message["type"] = "audio"
+        normalized_message["audio"] = message_body.get("audioMessage", {})
+    elif "documentMessage" in message_body:
+        normalized_message["type"] = "document"
+        normalized_message["document"] = message_body.get("documentMessage", {})
+    elif "stickerMessage" in message_body:
+        normalized_message["type"] = "sticker"
+        normalized_message["sticker"] = message_body.get("stickerMessage", {})
+    elif "locationMessage" in message_body:
+        normalized_message["type"] = "location"
+        normalized_message["location"] = message_body.get("locationMessage", {})
+    elif "reactionMessage" in message_body:
+        normalized_message["type"] = "reaction"
+        normalized_message["reaction"] = message_body.get("reactionMessage", {})
+    elif "contactMessage" in message_body:
+        normalized_message["type"] = "contacts"
+        normalized_message["contacts"] = [
+            message_body.get("contactMessage", {})
+        ]
+    elif "contactsArrayMessage" in message_body:
+        normalized_message["type"] = "contacts"
+        normalized_message["contacts"] = message_body.get(
+            "contactsArrayMessage", {}
+        ).get("contacts", [])
+    else:
+        normalized_message["type"] = message_type or "unknown"
+
+    metadata_extra = {
+        "integration": "evolution_api",
+        "message_type": message_type,
+        "from_me": key.get("fromMe"),
+        "remote_jid": remote_jid,
+        "instance_id": raw_message.get("instanceId"),
+        "push_name": raw_message.get("pushName"),
+    }
+
+    return normalized_message, metadata_extra
+
+
+def extract_message_text(message: dict[str, Any]) -> str:
+    """Return the human-readable text from a WhatsApp message payload."""
+
+    message_type = message.get("type")
+    if message_type == "text":
+        return message.get("text", {}).get("body", "")
+    if message_type == "interactive":
+        interactive = message.get("interactive", {})
+        if interactive.get("type") == "button_reply":
+            return interactive.get("button_reply", {}).get("title", "")
+        if interactive.get("type") == "list_reply":
+            reply = interactive.get("list_reply", {})
+            return reply.get("title") or reply.get("id", "")
+    return ""
+
+
+def handle_status_update(db: Session, status_payload: dict[str, Any]) -> None:
+    """Apply delivery status updates to the message log."""
+
+    message_id = (
+        status_payload.get("keyId")
+        or status_payload.get("id")
+        or status_payload.get("message_id")
+        or status_payload.get("messageId")
+    )
+    if not message_id:
+        return
+
+    stmt = select(MessageLog).where(
+        MessageLog.metadata_json["wa_message_id"].astext == message_id
+    )
+    message_log = db.execute(stmt).scalars().first()
+    if not message_log:
+        logger.debug("Received status for unknown message id %s", message_id)
+        return
+
+    status_value = status_payload.get("status")
+    if isinstance(status_value, str):
+        message_log.status = status_value.lower()
+    metadata = message_log.metadata_json or {}
+    if "keyId" in status_payload:
+        metadata.setdefault("integration", "evolution_api")
+        metadata["status_origin"] = "evolution_api"
+    history = metadata.setdefault("status_history", [])
+    history.append(status_payload)
+    message_log.metadata_json = metadata
+
+    timestamp = status_payload.get("timestamp")
+    if timestamp:
+        try:
+            message_log.sent_at = datetime.fromtimestamp(
+                int(timestamp), tz=timezone.utc
+            )
+        except (TypeError, ValueError):
+            logger.debug("Invalid status timestamp %s", timestamp)
+
+
+def handle_inbound_message(
+    db: Session,
+    message: dict[str, Any],
+    *,
+    raw_payload: dict[str, Any] | None = None,
+    metadata_extra: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Process inbound WhatsApp messages, update state, and optionally reply."""
+
+    phone = message.get("from")
+    timestamp = parse_timestamp(message.get("timestamp"))
+    tenant_id = ensure_default_tenant(db)
+
+    metadata: dict[str, Any] = {
+        "direction": "inbound",
+        "wa_message_id": message.get("id"),
+        "type": message.get("type"),
+    }
+    if metadata_extra:
+        metadata.update({k: v for k, v in metadata_extra.items() if v is not None})
+    persist_message_log(
+        db,
+        tenant_id=tenant_id,
+        channel="whatsapp",
+        recipient=phone,
+        payload=raw_payload or message,
+        metadata=metadata,
+        status="received",
+        sent_at=timestamp,
+    )
+
+    session_active = True
+    if phone:
+        session_active = last_interaction_within(
+            phone, WHATSAPP_SESSION_WINDOW, timestamp
+        )
+        record_last_interaction(phone, timestamp)
+
+    text_body = extract_message_text(message)
+    normalized = text_body.strip().lower()
+
+    state = get_state(phone) if phone else BotState.MENU_INICIAL
+    context = get_context(phone) if phone else {}
+    response_details: dict[str, Any] | None = None
+
+    if normalized == "agendar" and phone:
+        set_state(phone, BotState.AGENDAR)
+        if not session_active:
+            message_id, response_payload, request_payload = send_template(
+                to=phone,
+                template_name="confirmacao_consulta",
+                variables=[
+                    text_body or phone,
+                    settings.app_name,
+                    "em breve",
+                ],
+            )
+            response_details = log_outbound_message(
+                db,
+                tenant_id=tenant_id,
+                phone=phone,
+                request_payload=request_payload,
+                response_payload=response_payload,
+                response_type="template",
+                session_active=session_active,
+                metadata_extra={"template": "confirmacao_consulta"},
+            )
+            return response_details
+
+        provider = primary_provider(db, tenant_id)
+        services = service_options(db, tenant_id)
+        if not provider or not services:
+            message_text = (
+                "Estamos atualizando nossa agenda. Tente novamente em breve."
+            )
+            message_id, response_payload, request_payload = send_text(
+                to=phone, body=message_text
+            )
+            response_details = log_outbound_message(
+                db,
+                tenant_id=tenant_id,
+                phone=phone,
+                request_payload=request_payload,
+                response_payload=response_payload,
+                response_type="text",
+                session_active=session_active,
+                metadata_extra={"stage": "unavailable"},
+            )
+            clear_context(phone)
+            set_state(phone, BotState.MENU_INICIAL)
+            return response_details
+
+        display_name = None
+        if metadata_extra:
+            display_name = metadata_extra.get("push_name")
+        patient = ensure_patient_profile(
+            db,
+            tenant_id=tenant_id,
+            phone_number=phone,
+            display_name=display_name,
+        )
+        context = {
+            "stage": "service_selection",
+            "services": services,
+            "tenant_id": str(tenant_id),
+            "provider_id": str(provider.id),
+            "patient_id": str(patient.id),
+        }
+        set_context(phone, context)
+
+        message_id, response_payload, request_payload = send_interactive_buttons(
+            to=phone,
+            body=MENU_PROMPT,
+            buttons=MENU_BUTTONS,
+        )
+        log_outbound_message(
+            db,
+            tenant_id=tenant_id,
+            phone=phone,
+            request_payload=request_payload,
+            response_payload=response_payload,
+            response_type="interactive",
+            session_active=session_active,
+            metadata_extra={"buttons": MENU_BUTTONS, "stage": "menu"},
+        )
+
+        prompt_text = format_service_prompt(services)
+        message_id, response_payload, request_payload = send_text(
+            to=phone, body=prompt_text
+        )
+        response_details = log_outbound_message(
+            db,
+            tenant_id=tenant_id,
+            phone=phone,
+            request_payload=request_payload,
+            response_payload=response_payload,
+            response_type="text",
+            session_active=session_active,
+            metadata_extra={"stage": "service_selection"},
+        )
+        response_details["stage"] = "service_selection"
+        return response_details
+    elif normalized == "reagendar" and phone:
+        set_state(phone, BotState.REMARCAR)
+        clear_context(phone)
+    elif normalized in {"humano", "falar com atendente"} and phone:
+        set_state(phone, BotState.HUMANO)
+        clear_context(phone)
+
+    if phone and state == BotState.AGENDAR and context:
+        stage = context.get("stage")
+        tenant_key = context.get("tenant_id")
+        tenant_uuid = UUID(tenant_key) if tenant_key else tenant_id
+        tenant = db.get(Tenant, tenant_uuid)
+        tz = tenant_timezone(tenant)
+
+        if stage == "service_selection":
+            options = context.get("services", [])
+            selection = parse_service_choice(text_body, options)
+            if not selection:
+                message_text = (
+                    "Não entendi a escolha. Responda com o número do serviço desejado."
+                )
+                message_id, response_payload, request_payload = send_text(
+                    to=phone, body=message_text
+                )
+                response_details = log_outbound_message(
+                    db,
+                    tenant_id=tenant_id,
+                    phone=phone,
+                    request_payload=request_payload,
+                    response_payload=response_payload,
+                    response_type="text",
+                    session_active=session_active,
+                    metadata_extra={"stage": "service_selection", "error": "invalid_choice"},
+                )
+                return response_details
+
+            context["service_id"] = selection["id"]
+            context["service_name"] = selection["name"]
+            context["stage"] = "date_selection"
+            set_context(phone, context)
+
+            message_text = (
+                f"Ótimo! Para {selection['name']}, informe a data desejada no formato YYYY-MM-DD."
+            )
+            message_id, response_payload, request_payload = send_text(
+                to=phone, body=message_text
+            )
+            response_details = log_outbound_message(
+                db,
+                tenant_id=tenant_id,
+                phone=phone,
+                request_payload=request_payload,
+                response_payload=response_payload,
+                response_type="text",
+                session_active=session_active,
+                metadata_extra={"stage": "date_selection"},
+            )
+            response_details["stage"] = "date_selection"
+            return response_details
+
+        if stage == "date_selection":
+            selected_date = parse_date_choice(text_body)
+            if not selected_date:
+                message_id, response_payload, request_payload = send_text(
+                    to=phone,
+                    body="Data inválida. Use o formato YYYY-MM-DD.",
+                )
+                response_details = log_outbound_message(
+                    db,
+                    tenant_id=tenant_id,
+                    phone=phone,
+                    request_payload=request_payload,
+                    response_payload=response_payload,
+                    response_type="text",
+                    session_active=session_active,
+                    metadata_extra={"stage": "date_selection", "error": "invalid_format"},
+                )
+                return response_details
+
+            provider_id = context.get("provider_id")
+            service_id = context.get("service_id")
+            provider = db.get(Provider, UUID(provider_id)) if provider_id else None
+            service = db.get(Service, UUID(service_id)) if service_id else None
+            if not provider or not service or not tenant:
+                message_id, response_payload, request_payload = send_text(
+                    to=phone,
+                    body="Não foi possível encontrar a agenda. Por favor, tente novamente mais tarde.",
+                )
+                response_details = log_outbound_message(
+                    db,
+                    tenant_id=tenant_id,
+                    phone=phone,
+                    request_payload=request_payload,
+                    response_payload=response_payload,
+                    response_type="text",
+                    session_active=session_active,
+                    metadata_extra={"stage": "date_selection", "error": "missing_entities"},
+                )
+                clear_context(phone)
+                set_state(phone, BotState.MENU_INICIAL)
+                return response_details
+
+            held_slots, slot_tz = offer_slots(
+                db,
+                tenant=tenant,
+                provider=provider,
+                service=service,
+                target_date=selected_date,
+            )
+            slot_options = [slot.as_dict(slot_tz) for slot in held_slots]
+            context["slot_options"] = slot_options
+            context["selected_date"] = selected_date.isoformat()
+            context["timezone"] = getattr(slot_tz, "key", str(slot_tz))
+            context["stage"] = "time_selection" if slot_options else "date_selection"
+            set_context(phone, context)
+
+            prompt = format_slot_prompt(
+                slots=slot_options,
+                target_date=selected_date,
+                tz=slot_tz,
+                service_name=service.name,
+            )
+            message_id, response_payload, request_payload = send_text(
+                to=phone, body=prompt
+            )
+            response_details = log_outbound_message(
+                db,
+                tenant_id=tenant_id,
+                phone=phone,
+                request_payload=request_payload,
+                response_payload=response_payload,
+                response_type="text",
+                session_active=session_active,
+                metadata_extra={
+                    "stage": context["stage"],
+                    "slot_count": len(slot_options),
+                },
+            )
+            response_details["stage"] = context["stage"]
+            return response_details
+
+        if stage == "time_selection":
+            tz_name = context.get("timezone") or getattr(tz, "key", str(tz))
+            try:
+                slot_tz = ZoneInfo(tz_name)
+            except Exception:  # pragma: no cover - fallback safety
+                slot_tz = tz
+
+            slot_options = context.get("slot_options", [])
+            if not slot_options:
+                context["stage"] = "date_selection"
+                set_context(phone, context)
+                message_id, response_payload, request_payload = send_text(
+                    to=phone,
+                    body="Os horários expiraram. Informe uma nova data para continuar.",
+                )
+                response_details = log_outbound_message(
+                    db,
+                    tenant_id=tenant_id,
+                    phone=phone,
+                    request_payload=request_payload,
+                    response_payload=response_payload,
+                    response_type="text",
+                    session_active=session_active,
+                    metadata_extra={"stage": "date_selection", "error": "slots_expired"},
+                )
+                return response_details
+
+            choice = parse_slot_choice(text_body, slot_options, slot_tz)
+            if not choice:
+                message_id, response_payload, request_payload = send_text(
+                    to=phone,
+                    body="Não entendi o horário selecionado. Escolha um dos horários listados.",
+                )
+                response_details = log_outbound_message(
+                    db,
+                    tenant_id=tenant_id,
+                    phone=phone,
+                    request_payload=request_payload,
+                    response_payload=response_payload,
+                    response_type="text",
+                    session_active=session_active,
+                    metadata_extra={"stage": "time_selection", "error": "invalid_slot"},
+                )
+                return response_details
+
+            provider = db.get(Provider, UUID(context.get("provider_id")))
+            service = db.get(Service, UUID(context.get("service_id")))
+            patient = db.get(Patient, UUID(context.get("patient_id")))
+            if not provider or not service or not patient or not tenant:
+                message_id, response_payload, request_payload = send_text(
+                    to=phone,
+                    body="Não foi possível concluir o agendamento. Tente novamente.",
+                )
+                response_details = log_outbound_message(
+                    db,
+                    tenant_id=tenant_id,
+                    phone=phone,
+                    request_payload=request_payload,
+                    response_payload=response_payload,
+                    response_type="text",
+                    session_active=session_active,
+                    metadata_extra={"stage": "time_selection", "error": "missing_entities"},
+                )
+                clear_context(phone)
+                set_state(phone, BotState.MENU_INICIAL)
+                return response_details
+
+            slot_id = UUID(choice["slot_id"])
+            slot = lock_slot_by_id(db, slot_id)
+            if not slot:
+                message_id, response_payload, request_payload = send_text(
+                    to=phone,
+                    body="O horário escolhido não está mais disponível. Envie uma nova data.",
+                )
+                context["stage"] = "date_selection"
+                set_context(phone, context)
+                response_details = log_outbound_message(
+                    db,
+                    tenant_id=tenant_id,
+                    phone=phone,
+                    request_payload=request_payload,
+                    response_payload=response_payload,
+                    response_type="text",
+                    session_active=session_active,
+                    metadata_extra={"stage": "date_selection", "error": "slot_missing"},
+                )
+                return response_details
+
+            try:
+                appointment = book_slot(
+                    db,
+                    tenant=tenant,
+                    provider=provider,
+                    patient=patient,
+                    service=service,
+                    slot=slot,
+                    origin=AppointmentOrigin.WHATSAPP,
+                )
+            except ValueError:
+                message_id, response_payload, request_payload = send_text(
+                    to=phone,
+                    body="O horário acabou de ser reservado por outra pessoa. Envie uma nova data.",
+                )
+                context["stage"] = "date_selection"
+                set_context(phone, context)
+                response_details = log_outbound_message(
+                    db,
+                    tenant_id=tenant_id,
+                    phone=phone,
+                    request_payload=request_payload,
+                    response_payload=response_payload,
+                    response_type="text",
+                    session_active=session_active,
+                    metadata_extra={"stage": "date_selection", "error": "slot_conflict"},
+                )
+                return response_details
+
+            confirmation_tz = slot_tz
+            start_local = ensure_utc(appointment.scheduled_start).astimezone(
+                confirmation_tz
+            )
+            message_text = (
+                f"Consulta confirmada para {start_local.strftime('%d/%m/%Y às %H:%M')} com {service.name}."
+            )
+            message_id, response_payload, request_payload = send_text(
+                to=phone, body=message_text
+            )
+            response_details = log_outbound_message(
+                db,
+                tenant_id=tenant_id,
+                phone=phone,
+                request_payload=request_payload,
+                response_payload=response_payload,
+                response_type="text",
+                session_active=session_active,
+                metadata_extra={
+                    "stage": "completed",
+                    "appointment_id": str(appointment.id),
+                },
+            )
+            response_details["appointment"] = serialize_appointment(
+                appointment, tz=confirmation_tz
+            )
+            clear_context(phone)
+            set_state(phone, BotState.MENU_INICIAL)
+            return response_details
+
+    return response_details
+
+
+@app.get("/metrics")
+def metrics() -> Response:
+    """Expose Prometheus metrics for scraping."""
+
+    return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Health check endpoint used by infrastructure probes."""
+
+    return {"status": "ok"}
+
+
+@app.get("/api/v1/wa/webhook")
+def whatsapp_webhook_verification(
+    hub_mode: str | None = Query(default=None, alias="hub.mode"),
+    hub_challenge: str | None = Query(default=None, alias="hub.challenge"),
+    hub_verify_token: str | None = Query(default=None, alias="hub.verify_token"),
+):
+    """Handle the WhatsApp webhook verification handshake."""
+
+    if (
+        hub_mode == "subscribe"
+        and hub_verify_token
+        and hub_verify_token == settings.webhook_verify_token
+    ):
+        if not hub_challenge:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Missing hub.challenge",
+            )
+        return PlainTextResponse(content=hub_challenge)
+
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+
+@app.post("/api/v1/wa/webhook")
+def whatsapp_webhook(
+    payload: dict[str, Any],
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """Ingest WhatsApp events (messages and delivery statuses)."""
+
+    if not payload:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Payload required",
+        )
+
+    processed: list[dict[str, Any]] = []
+
+    event_name = payload.get("event")
+    if event_name:
+        event_key = str(event_name).upper()
+        event_data = payload.get("data")
+        items = event_data if isinstance(event_data, list) else [event_data]
+
+        if event_key == "MESSAGES_UPSERT":
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                normalized, extra_metadata = normalize_evolution_message(item)
+                result = handle_inbound_message(
+                    db,
+                    normalized,
+                    raw_payload=item,
+                    metadata_extra=extra_metadata,
+                )
+                if result:
+                    processed.append(result)
+        elif event_key in {"MESSAGES_UPDATE"}:
+            for status_update in items:
+                if isinstance(status_update, dict):
+                    handle_status_update(db, status_update)
+        else:
+            logger.debug("Unhandled Evolution webhook event: %s", event_name)
+
+        return {"status": "ok", "processed": processed, "event": event_name}
+
+    for entry in payload.get("entry", []):
+        for change in entry.get("changes", []):
+            value = change.get("value", {})
+            for message in value.get("messages", []) or []:
+                result = handle_inbound_message(db, message)
+                if result:
+                    processed.append(result)
+            for status_update in value.get("statuses", []) or []:
+                handle_status_update(db, status_update)
+
+    return {"status": "ok", "processed": processed}
+
+
+@app.get("/api/v1/slots/search")
+def search_slots(
+    provider_id: UUID,
+    service_id: UUID,
+    date: str,
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """Return available slots for a provider/service on a given date."""
+
+    provider = db.get(Provider, provider_id)
+    if not provider:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Provider not found")
+
+    set_tenant_context(provider.tenant_id)
+
+    service = db.get(Service, service_id)
+    if not service:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Service not found")
+
+    if service.tenant_id != provider.tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Provider and service belong to different tenants",
+        )
+
+    tenant = db.get(Tenant, provider.tenant_id)
+    if not tenant:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tenant not found")
+
+    set_tenant_context(tenant.id)
+
+    target_date = parse_date_choice(date)
+    if not target_date:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid date format. Use YYYY-MM-DD.",
+        )
+
+    held_slots, tz = offer_slots(
+        db,
+        tenant=tenant,
+        provider=provider,
+        service=service,
+        target_date=target_date,
+    )
+    serialized = [slot.as_dict(tz) for slot in held_slots]
+    for item in serialized:
+        item["duration_min"] = service.duration_min
+        item["price_cents"] = service.price_cents
+
+    tz_name = getattr(tz, "key", str(tz))
+    return {
+        "provider_id": str(provider_id),
+        "service_id": str(service_id),
+        "date": target_date.isoformat(),
+        "timezone": tz_name,
+        "results": serialized,
+    }
+
+
+@app.get("/api/v1/appointments")
+def list_appointments(
+    tenant_id: UUID,
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """List appointments for a tenant."""
+
+    tenant = db.get(Tenant, tenant_id)
+    if not tenant:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tenant not found")
+
+    set_tenant_context(tenant.id)
+
+    tz = tenant_timezone(tenant)
+    stmt = (
+        select(Appointment)
+        .where(Appointment.tenant_id == tenant_id)
+        .order_by(Appointment.scheduled_start)
+    )
+    appointments = db.execute(stmt).scalars().all()
+    return {
+        "tenant_id": str(tenant_id),
+        "appointments": [serialize_appointment(appt, tz=tz) for appt in appointments],
+    }
+
+
+@app.post("/api/v1/appointments", status_code=status.HTTP_201_CREATED)
+def create_appointment(
+    payload: AppointmentCreate,
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """Create a new appointment using a held slot."""
+
+    provider = db.get(Provider, payload.provider_id)
+    if not provider:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Provider not found")
+
+    patient = db.get(Patient, payload.patient_id)
+    if not patient:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Patient not found")
+
+    service = db.get(Service, payload.service_id)
+    if not service:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Service not found")
+
+    tenant = db.get(Tenant, provider.tenant_id)
+    if not tenant:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tenant not found")
+
+    set_tenant_context(tenant.id)
+
+    if service.tenant_id != provider.tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Provider and service belong to different tenants",
+        )
+    if patient.tenant_id != provider.tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Patient is registered in another tenant",
+        )
+
+    start_utc = to_utc_from_tenant(payload.start_ts, tenant)
+
+    slot: ScheduleSlot | None = None
+    if payload.schedule_slot_id:
+        slot = lock_slot_by_id(db, payload.schedule_slot_id)
+        if not slot:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Schedule slot not found",
+            )
+        if slot.provider_id != provider.id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Schedule slot belongs to another provider",
+            )
+    else:
+        slot = get_slot_by_start(db, provider_id=provider.id, start_ts=start_utc)
+        if not slot:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No slot available at the requested time",
+            )
+
+    try:
+        appointment = book_slot(
+            db,
+            tenant=tenant,
+            provider=provider,
+            patient=patient,
+            service=service,
+            slot=slot,
+            origin=payload.origin,
+            notes=payload.notes,
+        )
+    except ValueError as exc:  # slot no longer available
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+
+    tz = tenant_timezone(tenant)
+    return {"appointment": serialize_appointment(appointment, tz=tz)}
+
+
+@app.patch("/api/v1/appointments/{appointment_id}")
+def update_appointment_status(
+    appointment_id: UUID,
+    payload: AppointmentUpdate,
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """Update the status of an appointment."""
+
+    stmt = (
+        select(Appointment)
+        .where(Appointment.id == appointment_id)
+        .with_for_update()
+    )
+    appointment = db.execute(stmt).scalars().first()
+    if not appointment:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Appointment not found",
+        )
+
+    appointment.status = payload.status
+    if payload.notes is not None:
+        appointment.notes = payload.notes
+
+    tenant = db.get(Tenant, appointment.tenant_id)
+    if not tenant:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tenant not found")
+
+    set_tenant_context(tenant.id)
+
+    release_statuses = {
+        AppointmentStatus.CANCELLED,
+        AppointmentStatus.NO_SHOW,
+        AppointmentStatus.RESCHEDULED,
+    }
+    if payload.status in release_statuses and appointment.schedule_slot_id:
+        slot = db.get(ScheduleSlot, appointment.schedule_slot_id)
+        if slot:
+            slot.status = SlotStatus.FREE
+            slot.hold_expires_at = None
+
+    tz = tenant_timezone(tenant)
+    return {"appointment": serialize_appointment(appointment, tz=tz)}

--- a/sais/api/app/models/__init__.py
+++ b/sais/api/app/models/__init__.py
@@ -1,0 +1,24 @@
+"""SQLAlchemy models for the SAIS API."""
+
+from app.models.appointment import Appointment, AppointmentOrigin, AppointmentStatus
+from app.models.audit_log import AuditLog
+from app.models.message_log import MessageLog
+from app.models.patient import Patient
+from app.models.provider import Provider
+from app.models.schedule_slot import ScheduleSlot, SlotStatus
+from app.models.service import Service
+from app.models.tenant import Tenant
+
+__all__ = [
+    "Appointment",
+    "AppointmentOrigin",
+    "AppointmentStatus",
+    "AuditLog",
+    "MessageLog",
+    "Patient",
+    "Provider",
+    "ScheduleSlot",
+    "SlotStatus",
+    "Service",
+    "Tenant",
+]

--- a/sais/api/app/models/appointment.py
+++ b/sais/api/app/models/appointment.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import enum
+import uuid
+
+from sqlalchemy import DateTime, Enum, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class AppointmentStatus(str, enum.Enum):
+    """Possible statuses for an appointment lifecycle."""
+
+    CONFIRMED = "CONFIRMED"
+    RESCHEDULED = "RESCHEDULED"
+    CANCELLED = "CANCELLED"
+    NO_SHOW = "NO_SHOW"
+    COMPLETED = "COMPLETED"
+
+
+class AppointmentOrigin(str, enum.Enum):
+    """Origin of an appointment booking."""
+
+    WHATSAPP = "WHATSAPP"
+    WEB = "WEB"
+    STAFF = "STAFF"
+
+
+class Appointment(Base, TimestampMixin):
+    """Appointment between a patient and provider."""
+
+    __tablename__ = "appointments"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), index=True
+    )
+    patient_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("patients.id", ondelete="CASCADE"), index=True
+    )
+    provider_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("providers.id", ondelete="CASCADE"), index=True
+    )
+    service_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("services.id", ondelete="SET NULL"), nullable=True
+    )
+    schedule_slot_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("schedule_slots.id", ondelete="SET NULL"), nullable=True
+    )
+    status: Mapped[AppointmentStatus] = mapped_column(
+        Enum(AppointmentStatus, name="appointment_status"),
+        default=AppointmentStatus.CONFIRMED,
+        nullable=False,
+    )
+    scheduled_start: Mapped[DateTime | None] = mapped_column(DateTime, nullable=True)
+    scheduled_end: Mapped[DateTime | None] = mapped_column(DateTime, nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    origin: Mapped[AppointmentOrigin] = mapped_column(
+        Enum(AppointmentOrigin, name="appointment_origin"),
+        default=AppointmentOrigin.WHATSAPP,
+        nullable=False,
+    )

--- a/sais/api/app/models/audit_log.py
+++ b/sais/api/app/models/audit_log.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class AuditLog(Base, TimestampMixin):
+    """Audit trail entry scoped per tenant."""
+
+    __tablename__ = "audit_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), index=True
+    )
+    actor: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    action: Mapped[str] = mapped_column(String(255), nullable=False)
+    resource: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    occurred_at: Mapped[DateTime] = mapped_column(DateTime, nullable=False)
+    metadata_json: Mapped[dict | None] = mapped_column("metadata", JSONB, nullable=True)

--- a/sais/api/app/models/base.py
+++ b/sais/api/app/models/base.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import MetaData
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+convention = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+
+class Base(DeclarativeBase):
+    """Base declarative class with default metadata convention."""
+
+    metadata = MetaData(naming_convention=convention)
+
+
+class TimestampMixin:
+    """Mixin providing created and updated timestamps."""
+
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+
+class TenantScopedMixin:
+    """Mixin ensuring multi-tenant awareness for models."""
+
+    tenant_id: Mapped[Any]  # actual column declared per model to allow typing flexibility

--- a/sais/api/app/models/message_log.py
+++ b/sais/api/app/models/message_log.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class MessageLog(Base, TimestampMixin):
+    """Outbound and inbound communication log."""
+
+    __tablename__ = "message_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), index=True
+    )
+    appointment_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("appointments.id", ondelete="SET NULL"), nullable=True
+    )
+    channel: Mapped[str] = mapped_column(String(32), nullable=False)
+    recipient: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    payload: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metadata_json: Mapped[dict | None] = mapped_column("metadata", JSONB, nullable=True)
+    status: Mapped[str] = mapped_column(String(32), default="pending")
+    sent_at: Mapped[DateTime | None] = mapped_column(DateTime, nullable=True)

--- a/sais/api/app/models/patient.py
+++ b/sais/api/app/models/patient.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Date, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class Patient(Base, TimestampMixin):
+    """Patient entity scoped by tenant."""
+
+    __tablename__ = "patients"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), index=True
+    )
+    full_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    phone_number: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    date_of_birth: Mapped[Date | None] = mapped_column(Date, nullable=True)

--- a/sais/api/app/models/provider.py
+++ b/sais/api/app/models/provider.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class Provider(Base, TimestampMixin):
+    """Care provider (doctor, nurse, etc.)."""
+
+    __tablename__ = "providers"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), index=True
+    )
+    full_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    specialty: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/sais/api/app/models/schedule_slot.py
+++ b/sais/api/app/models/schedule_slot.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import enum
+import uuid
+
+from sqlalchemy import DateTime, Enum, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class SlotStatus(str, enum.Enum):
+    """Possible states for a schedule slot."""
+
+    FREE = "FREE"
+    HOLD = "HOLD"
+    BOOKED = "BOOKED"
+    BLOCKED = "BLOCKED"
+
+
+class ScheduleSlot(Base, TimestampMixin):
+    """Bookable schedule slots for providers."""
+
+    __tablename__ = "schedule_slots"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), index=True
+    )
+    provider_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("providers.id", ondelete="CASCADE"), index=True
+    )
+    service_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("services.id", ondelete="SET NULL"), nullable=True
+    )
+    start_time: Mapped[DateTime] = mapped_column(DateTime, nullable=False)
+    end_time: Mapped[DateTime] = mapped_column(DateTime, nullable=False)
+    status: Mapped[SlotStatus] = mapped_column(
+        Enum(SlotStatus, name="schedule_slot_status"),
+        default=SlotStatus.FREE,
+        nullable=False,
+    )
+    hold_expires_at: Mapped[DateTime | None] = mapped_column(DateTime, nullable=True)

--- a/sais/api/app/models/service.py
+++ b/sais/api/app/models/service.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class Service(Base, TimestampMixin):
+    """Clinical service offering."""
+
+    __tablename__ = "services"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), index=True
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    duration_min: Mapped[int] = mapped_column(Integer, default=30)
+    price_cents: Mapped[int] = mapped_column(Integer, default=0)

--- a/sais/api/app/models/tenant.py
+++ b/sais/api/app/models/tenant.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Boolean, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class Tenant(Base, TimestampMixin):
+    """Tenant entity representing a clinic or organization."""
+
+    __tablename__ = "tenants"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    timezone: Mapped[str] = mapped_column(String(64), default="America/Fortaleza")
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)

--- a/sais/api/app/seed.py
+++ b/sais/api/app/seed.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, time, timedelta, timezone
+from typing import Iterable
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.db.session import SessionLocal
+from app.logging_utils import configure_logging, set_tenant_context
+from app.models import Patient, Provider, ScheduleSlot, Service, SlotStatus, Tenant
+
+logger = logging.getLogger(__name__)
+
+SERVICE_CATALOG: list[tuple[str, int, int]] = [
+    ("Avaliação Odontológica", 30, 15000),
+    ("Limpeza Profissional", 45, 25000),
+    ("Clareamento Dental", 60, 48000),
+]
+
+PROVIDERS: list[tuple[str, str]] = [
+    ("Dra. Ana Costa", "Ortodontista"),
+    ("Dr. Bruno Lima", "Implantodontista"),
+]
+
+PATIENTS: list[tuple[str, str, str]] = [
+    ("Maria Silva", "maria.silva@example.com", "+5585987654321"),
+    ("João Pereira", "joao.pereira@example.com", "+558593334455"),
+]
+
+
+def ensure_tenant(session) -> Tenant:
+    tenant = (
+        session.execute(
+            select(Tenant).where(Tenant.name == "Clínica SAIS Demo")
+        ).scalar_one_or_none()
+    )
+    if tenant:
+        set_tenant_context(tenant.id)
+        logger.info("tenant already present", extra={"tenant_id": str(tenant.id)})
+        return tenant
+
+    tenant = Tenant(name="Clínica SAIS Demo", timezone=settings.timezone)
+    session.add(tenant)
+    session.flush()
+    set_tenant_context(tenant.id)
+    logger.info("created tenant", extra={"tenant_id": str(tenant.id)})
+    return tenant
+
+
+def ensure_services(session, tenant: Tenant) -> list[Service]:
+    created = 0
+    services: list[Service] = []
+    for name, duration, price in SERVICE_CATALOG:
+        service = (
+            session.execute(
+                select(Service).where(
+                    Service.tenant_id == tenant.id,
+                    Service.name == name,
+                )
+            ).scalar_one_or_none()
+        )
+        if not service:
+            service = Service(
+                tenant_id=tenant.id,
+                name=name,
+                duration_min=duration,
+                price_cents=price,
+            )
+            session.add(service)
+            session.flush()
+            created += 1
+        services.append(service)
+
+    logger.info(
+        "ensured services",
+        extra={"tenant_id": str(tenant.id), "created": created, "total": len(services)},
+    )
+    return services
+
+
+def ensure_providers(session, tenant: Tenant) -> list[Provider]:
+    created = 0
+    providers: list[Provider] = []
+    for name, specialty in PROVIDERS:
+        provider = (
+            session.execute(
+                select(Provider).where(
+                    Provider.tenant_id == tenant.id,
+                    Provider.full_name == name,
+                )
+            ).scalar_one_or_none()
+        )
+        if not provider:
+            provider = Provider(
+                tenant_id=tenant.id,
+                full_name=name,
+                specialty=specialty,
+            )
+            session.add(provider)
+            session.flush()
+            created += 1
+        providers.append(provider)
+
+    logger.info(
+        "ensured providers",
+        extra={"tenant_id": str(tenant.id), "created": created, "total": len(providers)},
+    )
+    return providers
+
+
+def ensure_patients(session, tenant: Tenant) -> list[Patient]:
+    created = 0
+    patients: list[Patient] = []
+    for name, email, phone in PATIENTS:
+        patient = (
+            session.execute(
+                select(Patient).where(
+                    Patient.tenant_id == tenant.id,
+                    Patient.full_name == name,
+                )
+            ).scalar_one_or_none()
+        )
+        if not patient:
+            patient = Patient(
+                tenant_id=tenant.id,
+                full_name=name,
+                email=email,
+                phone_number=phone,
+            )
+            session.add(patient)
+            session.flush()
+            created += 1
+        patients.append(patient)
+
+    logger.info(
+        "ensured patients",
+        extra={"tenant_id": str(tenant.id), "created": created, "total": len(patients)},
+    )
+    return patients
+
+
+def ensure_slots(session, tenant: Tenant, providers: Iterable[Provider]) -> None:
+    tz = ZoneInfo(tenant.timezone or settings.timezone)
+    today = datetime.now(tz).date()
+    created = 0
+
+    for provider in providers:
+        for offset in range(5):
+            day = today + timedelta(days=offset)
+            for start_hour in range(9, 17):
+                local_start = datetime.combine(day, time(hour=start_hour, minute=0), tzinfo=tz)
+                start_utc = local_start.astimezone(timezone.utc)
+                end_utc = start_utc + timedelta(minutes=45)
+                existing = (
+                    session.execute(
+                        select(ScheduleSlot).where(
+                            ScheduleSlot.provider_id == provider.id,
+                            ScheduleSlot.start_time == start_utc,
+                        )
+                    ).scalar_one_or_none()
+                )
+                if existing:
+                    continue
+                slot = ScheduleSlot(
+                    tenant_id=tenant.id,
+                    provider_id=provider.id,
+                    start_time=start_utc,
+                    end_time=end_utc,
+                    status=SlotStatus.FREE,
+                )
+                session.add(slot)
+                created += 1
+
+    logger.info(
+        "ensured schedule slots",
+        extra={"tenant_id": str(tenant.id), "created": created},
+    )
+
+
+def seed() -> None:
+    configure_logging()
+    logger.info("starting seed process")
+
+    session = SessionLocal()
+    try:
+        tenant = ensure_tenant(session)
+        set_tenant_context(tenant.id)
+        ensure_services(session, tenant)
+        providers = ensure_providers(session, tenant)
+        ensure_patients(session, tenant)
+        ensure_slots(session, tenant, providers)
+        session.commit()
+        logger.info("seed complete", extra={"tenant_id": str(tenant.id)})
+    except Exception:
+        session.rollback()
+        logger.exception("seed failed")
+        raise
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":  # pragma: no cover - script entrypoint
+    seed()

--- a/sais/api/app/services/__init__.py
+++ b/sais/api/app/services/__init__.py
@@ -1,0 +1,29 @@
+"""Service layer utilities for the SAIS API."""
+
+from app.services.bot_state import (
+    BotState,
+    clear_context,
+    get_context,
+    get_state,
+    record_last_interaction,
+    set_context,
+    set_state,
+)
+from app.services.whatsapp_client import (
+    send_interactive_buttons,
+    send_template,
+    send_text,
+)
+
+__all__ = [
+    "BotState",
+    "clear_context",
+    "get_context",
+    "get_state",
+    "record_last_interaction",
+    "set_context",
+    "set_state",
+    "send_interactive_buttons",
+    "send_template",
+    "send_text",
+]

--- a/sais/api/app/services/bot_state.py
+++ b/sais/api/app/services/bot_state.py
@@ -1,0 +1,119 @@
+"""Conversation state management backed by Redis."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Any, Final
+
+import redis
+
+from app.core.config import settings
+
+_STATE_KEY_TEMPLATE: Final[str] = "sais:wa:state:{phone}"
+_LAST_INTERACTION_KEY_TEMPLATE: Final[str] = "sais:wa:last_interaction:{phone}"
+_CONTEXT_KEY_TEMPLATE: Final[str] = "sais:wa:context:{phone}"
+_STATE_TTL_SECONDS: Final[int] = 60 * 60 * 24 * 7  # one week
+
+
+class BotState(str, Enum):
+    """Enumerated conversation states for the WhatsApp bot."""
+
+    MENU_INICIAL = "MENU_INICIAL"
+    AGENDAR = "AGENDAR"
+    REMARCAR = "REMARCAR"
+    HUMANO = "HUMANO"
+
+
+def _get_client() -> redis.Redis:
+    """Return a Redis client configured via application settings."""
+
+    return redis.Redis.from_url(settings.redis_url, decode_responses=True)
+
+
+def get_state(phone_e164: str) -> BotState:
+    """Fetch the current state for a WhatsApp contact."""
+
+    client = _get_client()
+    raw_state = client.get(_STATE_KEY_TEMPLATE.format(phone=phone_e164))
+    if not raw_state:
+        return BotState.MENU_INICIAL
+    try:
+        return BotState(raw_state)
+    except ValueError:
+        return BotState.MENU_INICIAL
+
+
+def set_state(phone_e164: str, state: BotState) -> None:
+    """Persist the bot state for a contact."""
+
+    client = _get_client()
+    client.setex(
+        _STATE_KEY_TEMPLATE.format(phone=phone_e164),
+        _STATE_TTL_SECONDS,
+        state.value,
+    )
+
+
+def record_last_interaction(phone_e164: str, timestamp: datetime) -> None:
+    """Store the timestamp of the latest interaction for the contact."""
+
+    client = _get_client()
+    client.setex(
+        _LAST_INTERACTION_KEY_TEMPLATE.format(phone=phone_e164),
+        _STATE_TTL_SECONDS,
+        timestamp.isoformat(),
+    )
+
+
+def get_context(phone_e164: str) -> dict[str, Any]:
+    """Return the structured context stored for the contact."""
+
+    client = _get_client()
+    raw_value = client.get(_CONTEXT_KEY_TEMPLATE.format(phone=phone_e164))
+    if not raw_value:
+        return {}
+    try:
+        data = json.loads(raw_value)
+        if isinstance(data, dict):
+            return data
+    except json.JSONDecodeError:
+        return {}
+    return {}
+
+
+def set_context(phone_e164: str, context: dict[str, Any]) -> None:
+    """Persist conversation context for the contact."""
+
+    client = _get_client()
+    client.setex(
+        _CONTEXT_KEY_TEMPLATE.format(phone=phone_e164),
+        _STATE_TTL_SECONDS,
+        json.dumps(context, ensure_ascii=False),
+    )
+
+
+def clear_context(phone_e164: str) -> None:
+    """Remove any stored context for the contact."""
+
+    client = _get_client()
+    client.delete(_CONTEXT_KEY_TEMPLATE.format(phone=phone_e164))
+
+
+def last_interaction_within(
+    phone_e164: str, delta: timedelta, reference: datetime
+) -> bool:
+    """Return whether the last interaction was within the provided time delta."""
+
+    client = _get_client()
+    raw_value = client.get(_LAST_INTERACTION_KEY_TEMPLATE.format(phone=phone_e164))
+    if not raw_value:
+        # Consider no history as within window to keep onboarding simple.
+        return True
+
+    try:
+        last_seen = datetime.fromisoformat(raw_value)
+    except ValueError:
+        return False
+    return reference - last_seen <= delta

--- a/sais/api/app/services/scheduling.py
+++ b/sais/api/app/services/scheduling.py
@@ -1,0 +1,303 @@
+"""Scheduling utilities for slot discovery and booking."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models import (
+    Appointment,
+    AppointmentOrigin,
+    AppointmentStatus,
+    Patient,
+    Provider,
+    ScheduleSlot,
+    Service,
+    SlotStatus,
+    Tenant,
+)
+
+HOLD_DURATION = timedelta(seconds=30)
+SLOT_SEARCH_LIMIT = 6
+DEFAULT_BUFFER_MINUTES = 10
+
+
+@dataclass
+class SlotSummary:
+    """Serialized view of a slot held for presentation."""
+
+    slot_id: UUID
+    provider_id: UUID
+    service_id: UUID | None
+    start_utc: datetime
+    end_utc: datetime
+    hold_expires_at: datetime | None
+    status: SlotStatus
+
+    def as_dict(self, tz: ZoneInfo) -> dict[str, str | UUID | None]:
+        """Convert the slot summary into JSON-friendly values."""
+
+        local_start = self.start_utc.astimezone(tz)
+        local_end = self.end_utc.astimezone(tz)
+        hold_value = (
+            self.hold_expires_at.astimezone(tz).isoformat()
+            if self.hold_expires_at
+            else None
+        )
+        return {
+            "slot_id": str(self.slot_id),
+            "provider_id": str(self.provider_id),
+            "service_id": str(self.service_id) if self.service_id else None,
+            "start_ts": self.start_utc.isoformat(),
+            "end_ts": self.end_utc.isoformat(),
+            "start_local": local_start.isoformat(),
+            "end_local": local_end.isoformat(),
+            "hold_expires_at": hold_value,
+            "status": self.status.value,
+        }
+
+
+def tenant_timezone(tenant: Tenant | None) -> ZoneInfo:
+    """Return the tenant timezone, falling back to application default."""
+
+    tz_name = (tenant.timezone if tenant else None) or settings.timezone
+    try:
+        return ZoneInfo(tz_name)
+    except Exception:  # pragma: no cover - defensive fallback
+        return ZoneInfo("UTC")
+
+
+def ensure_utc(value: datetime) -> datetime:
+    """Coerce a datetime into UTC timezone-aware form."""
+
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _day_bounds(target_date: date, tz: ZoneInfo) -> tuple[datetime, datetime]:
+    start = datetime.combine(target_date, time.min, tzinfo=tz)
+    end = start + timedelta(days=1)
+    return start.astimezone(timezone.utc), end.astimezone(timezone.utc)
+
+
+def release_expired_holds(db: Session, provider_id: UUID) -> int:
+    """Release expired holds for the given provider."""
+
+    now = datetime.now(timezone.utc)
+    stmt = (
+        update(ScheduleSlot)
+        .where(
+            ScheduleSlot.provider_id == provider_id,
+            ScheduleSlot.status == SlotStatus.HOLD,
+            ScheduleSlot.hold_expires_at.is_not(None),
+            ScheduleSlot.hold_expires_at <= now,
+        )
+        .values(status=SlotStatus.FREE, hold_expires_at=None)
+    )
+    result = db.execute(stmt)
+    return int(result.rowcount or 0)
+
+
+def _blocking_slots(slots: Sequence[ScheduleSlot], now: datetime) -> list[ScheduleSlot]:
+    blocked: list[ScheduleSlot] = []
+    for slot in slots:
+        if slot.status == SlotStatus.BLOCKED or slot.status == SlotStatus.BOOKED:
+            blocked.append(slot)
+        elif slot.status == SlotStatus.HOLD and slot.hold_expires_at:
+            expires = ensure_utc(slot.hold_expires_at)
+            if expires <= now:
+                slot.status = SlotStatus.FREE
+                slot.hold_expires_at = None
+            else:
+                blocked.append(slot)
+    return blocked
+
+
+def offer_slots(
+    db: Session,
+    *,
+    tenant: Tenant,
+    provider: Provider,
+    service: Service,
+    target_date: date,
+    limit: int = SLOT_SEARCH_LIMIT,
+    buffer_minutes: int = DEFAULT_BUFFER_MINUTES,
+) -> tuple[list[SlotSummary], ZoneInfo]:
+    """Return up to ``limit`` slots held for the caller."""
+
+    tz = tenant_timezone(tenant)
+    start_utc, end_utc = _day_bounds(target_date, tz)
+    now = datetime.now(timezone.utc)
+
+    release_expired_holds(db, provider.id)
+
+    stmt = (
+        select(ScheduleSlot)
+        .where(
+            ScheduleSlot.provider_id == provider.id,
+            ScheduleSlot.start_time >= start_utc,
+            ScheduleSlot.start_time < end_utc,
+        )
+        .order_by(ScheduleSlot.start_time)
+    )
+    slots = db.execute(stmt).scalars().all()
+
+    blocking = _blocking_slots(slots, now)
+    held: list[SlotSummary] = []
+    hold_until = now + HOLD_DURATION
+
+    for slot in slots:
+        if slot.status != SlotStatus.FREE:
+            continue
+
+        start = ensure_utc(slot.start_time)
+        end = ensure_utc(slot.end_time)
+        if (end - start).total_seconds() / 60 < service.duration_min:
+            continue
+
+        conflict = False
+        for busy in blocking:
+            if busy.id == slot.id:
+                continue
+            busy_start = ensure_utc(busy.start_time)
+            busy_end = ensure_utc(busy.end_time)
+
+            if busy_end <= start:
+                gap = (start - busy_end).total_seconds() / 60
+                if gap < buffer_minutes:
+                    conflict = True
+                    break
+            elif end <= busy_start:
+                gap = (busy_start - end).total_seconds() / 60
+                if gap < buffer_minutes:
+                    conflict = True
+                    break
+            else:
+                conflict = True
+                break
+
+        if conflict:
+            continue
+
+        slot.status = SlotStatus.HOLD
+        slot.hold_expires_at = hold_until
+        blocking.append(slot)
+        held.append(
+            SlotSummary(
+                slot_id=slot.id,
+                provider_id=slot.provider_id,
+                service_id=slot.service_id,
+                start_utc=start,
+                end_utc=end,
+                hold_expires_at=hold_until,
+                status=SlotStatus.HOLD,
+            )
+        )
+
+        if len(held) >= limit:
+            break
+
+    db.flush()
+    return held, tz
+
+
+def get_slot_by_start(
+    db: Session,
+    *,
+    provider_id: UUID,
+    start_ts: datetime,
+) -> ScheduleSlot | None:
+    """Return the slot that starts at the provided timestamp, locking it."""
+
+    statement = (
+        select(ScheduleSlot)
+        .where(
+            ScheduleSlot.provider_id == provider_id,
+            ScheduleSlot.start_time == ensure_utc(start_ts),
+        )
+        .with_for_update()
+    )
+    return db.execute(statement).scalars().first()
+
+
+def book_slot(
+    db: Session,
+    *,
+    tenant: Tenant,
+    provider: Provider,
+    patient: Patient,
+    service: Service,
+    slot: ScheduleSlot,
+    origin: AppointmentOrigin,
+    notes: str | None = None,
+) -> Appointment:
+    """Confirm a slot into an appointment."""
+
+    now = datetime.now(timezone.utc)
+    start = ensure_utc(slot.start_time)
+    end = ensure_utc(slot.end_time)
+    required_end = start + timedelta(minutes=service.duration_min)
+    if required_end > end:
+        raise ValueError("Slot duration is shorter than the service duration")
+
+    if slot.status == SlotStatus.HOLD:
+        if not slot.hold_expires_at or ensure_utc(slot.hold_expires_at) <= now:
+            slot.status = SlotStatus.FREE
+            slot.hold_expires_at = None
+            raise ValueError("Slot hold expired")
+    elif slot.status != SlotStatus.FREE:
+        raise ValueError("Slot unavailable")
+
+    slot.status = SlotStatus.BOOKED
+    slot.hold_expires_at = None
+    slot.service_id = service.id
+
+    appointment = Appointment(
+        tenant_id=tenant.id,
+        patient_id=patient.id,
+        provider_id=provider.id,
+        service_id=service.id,
+        schedule_slot_id=slot.id,
+        status=AppointmentStatus.CONFIRMED,
+        scheduled_start=start,
+        scheduled_end=required_end,
+        notes=notes,
+        origin=origin,
+    )
+    db.add(appointment)
+    db.flush()
+    return appointment
+
+
+def serialize_appointment(
+    appointment: Appointment,
+    *,
+    tz: ZoneInfo,
+) -> dict[str, str]:
+    """Return a JSON-friendly representation of an appointment."""
+
+    start_local = ensure_utc(appointment.scheduled_start).astimezone(tz)
+    end_local = ensure_utc(appointment.scheduled_end).astimezone(tz)
+    return {
+        "id": str(appointment.id),
+        "status": appointment.status.value,
+        "origin": appointment.origin.value,
+        "scheduled_start": ensure_utc(appointment.scheduled_start).isoformat()
+        if appointment.scheduled_start
+        else None,
+        "scheduled_end": ensure_utc(appointment.scheduled_end).isoformat()
+        if appointment.scheduled_end
+        else None,
+        "scheduled_start_local": start_local.isoformat(),
+        "scheduled_end_local": end_local.isoformat(),
+        "provider_id": str(appointment.provider_id),
+        "patient_id": str(appointment.patient_id),
+        "service_id": str(appointment.service_id) if appointment.service_id else None,
+    }

--- a/sais/api/app/services/whatsapp_client.py
+++ b/sais/api/app/services/whatsapp_client.py
@@ -1,0 +1,145 @@
+"""Thin wrapper around the Evolution WhatsApp API."""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from typing import Iterable, Sequence
+from urllib.parse import quote
+
+import httpx
+
+from app.core.config import settings
+from app.services.whatsapp_templates import TEMPLATE_MOCKS
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = httpx.Timeout(connect=5.0, read=15.0, write=15.0, pool=5.0)
+
+
+def _build_evolution_url(action: str) -> str:
+    base_url = settings.evolution_api_base_url.rstrip("/")
+    instance_name = settings.evolution_instance_name
+    if not instance_name:
+        raise RuntimeError("EVOLUTION_INSTANCE_NAME is not configured")
+    return f"{base_url}/message/{action}/{quote(instance_name)}"
+
+
+def _mock_send(action: str, payload: dict) -> tuple[str, dict]:
+    message_id = f"mocked-{uuid.uuid4()}"
+    logger.debug("Mocking Evolution send (%s) with payload: %s", action, payload)
+    phone = payload.get("number")
+    normalized_phone = re.sub(r"\D", "", phone or "")
+    mock_response = {
+        "key": {
+            "id": message_id,
+            "remoteJid": f"{normalized_phone or '00000000000'}@mock",
+        },
+        "messageType": action,
+        "mocked": True,
+        "payload": payload,
+    }
+    if action == "sendTemplate":
+        template_name = payload.get("name", "")
+        mock_response["template"] = TEMPLATE_MOCKS.get(template_name)
+    return message_id, mock_response
+
+
+def _dispatch(action: str, payload: dict) -> tuple[str, dict]:
+    if settings.whatsapp_mock_mode:
+        return _mock_send(action, payload)
+
+    api_key = settings.evolution_api_key
+    if not api_key:
+        raise RuntimeError("EVOLUTION_API_KEY is not configured")
+
+    url = _build_evolution_url(action)
+    headers = {
+        "apikey": api_key,
+        "Content-Type": "application/json",
+    }
+
+    with httpx.Client(timeout=_TIMEOUT) as client:
+        response = client.post(url, headers=headers, json=payload)
+    response.raise_for_status()
+    data = response.json()
+    message_id = (
+        data.get("key", {}).get("id")
+        or data.get("id")
+        or data.get("message", {}).get("key", {}).get("id")
+    )
+    if not message_id:
+        raise RuntimeError("Evolution API response did not include a message identifier")
+
+    logger.debug("Evolution API responded with %s", data)
+    return message_id, data
+
+
+def send_template(
+    to: str,
+    template_name: str,
+    variables: Iterable[str] | None = None,
+    language_code: str = "pt_BR",
+) -> tuple[str, dict, dict]:
+    """Send a template-based WhatsApp message."""
+
+    components = []
+    if variables:
+        components.append(
+            {
+                "type": "body",
+                "parameters": [
+                    {"type": "text", "text": str(value)} for value in variables
+                ],
+            }
+        )
+
+    payload = {
+        "number": to,
+        "name": template_name,
+        "language": language_code,
+        "components": components,
+    }
+    message_id, response = _dispatch("sendTemplate", payload)
+    return message_id, response, payload
+
+
+def send_interactive_buttons(
+    to: str, body: str, buttons: Sequence[str]
+) -> tuple[str, dict, dict]:
+    """Send an interactive message containing up to three quick-reply buttons."""
+
+    if not buttons:
+        raise ValueError("At least one button title must be provided")
+    if len(buttons) > 3:
+        raise ValueError("WhatsApp only supports up to 3 buttons in a message")
+
+    action_buttons = []
+    for index, title in enumerate(buttons, start=1):
+        action_buttons.append(
+            {
+                "type": "reply",
+                "id": f"option_{index}",
+                "displayText": title,
+            }
+        )
+
+    payload = {
+        "number": to,
+        "title": body,
+        "buttons": action_buttons,
+    }
+    message_id, response = _dispatch("sendButtons", payload)
+    return message_id, response, payload
+
+
+def send_text(
+    to: str,
+    body: str,
+) -> tuple[str, dict, dict]:
+    """Send a simple text message via WhatsApp."""
+
+    payload = {"number": to, "text": body}
+    message_id, response = _dispatch("sendText", payload)
+    return message_id, response, payload

--- a/sais/api/app/services/whatsapp_templates.py
+++ b/sais/api/app/services/whatsapp_templates.py
@@ -1,0 +1,25 @@
+"""Mock WhatsApp templates for development environments."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+TEMPLATE_MOCKS: Dict[str, Dict[str, Any]] = {
+    "confirmacao_consulta": {
+        "category": "TRANSACTIONAL",
+        "language": "pt_BR",
+        "body": "Olá {{1}}, sua consulta com {{2}} está confirmada para {{3}}.",
+    },
+    "lembrete_d1": {
+        "category": "TRANSACTIONAL",
+        "language": "pt_BR",
+        "body": "Lembrete: você possui uma consulta em 1 dia. Responda 1 para confirmar.",
+    },
+    "pos_consulta_nps": {
+        "category": "MARKETING",
+        "language": "pt_BR",
+        "body": "Como foi sua experiência? Responda de 0 a 10 para avaliarmos.",
+    },
+}
+
+__all__ = ["TEMPLATE_MOCKS"]

--- a/sais/api/requirements.txt
+++ b/sais/api/requirements.txt
@@ -1,0 +1,12 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+sqlalchemy==2.0.29
+alembic==1.13.1
+psycopg2-binary==2.9.9
+pydantic-settings==2.2.1
+python-dotenv==1.0.1
+celery==5.3.6
+redis==5.0.3
+httpx==0.27.0
+prometheus-client==0.20.0
+pytest==8.1.1

--- a/sais/api/tests/conftest.py
+++ b/sais/api/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/sais/api/tests/test_observability.py
+++ b/sais/api/tests/test_observability.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_health_endpoint():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_metrics_endpoint():
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert "sais_api_requests_total" in response.text
+    assert response.headers["content-type"].startswith("text/plain")

--- a/sais/docker-compose.yml
+++ b/sais/docker-compose.yml
@@ -1,0 +1,107 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-sais}
+      POSTGRES_USER: ${POSTGRES_USER:-sais}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-sais}
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sais} -d ${POSTGRES_DB:-sais}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+  api:
+    image: sais-api:latest
+    build:
+      context: .
+      dockerfile: ops/docker/api.Dockerfile
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg2://${POSTGRES_USER:-sais}:${POSTGRES_PASSWORD:-sais}@db:5432/${POSTGRES_DB:-sais}}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      TZ: ${TZ:-America/Fortaleza}
+      CORS_ORIGINS: ${CORS_ORIGINS:-["http://localhost:3000"]}
+      RATE_LIMIT_REQUESTS: ${RATE_LIMIT_REQUESTS:-120}
+      RATE_LIMIT_WINDOW_SECONDS: ${RATE_LIMIT_WINDOW_SECONDS:-60}
+      EVOLUTION_API_BASE_URL: ${EVOLUTION_API_BASE_URL:-http://evolution:8080}
+      EVOLUTION_INSTANCE_NAME: ${EVOLUTION_INSTANCE_NAME:-}
+      EVOLUTION_API_KEY: ${EVOLUTION_API_KEY:-}
+      WEBHOOK_VERIFY_TOKEN: ${WEBHOOK_VERIFY_TOKEN:-}
+      WHATSAPP_MOCK_MODE: ${WHATSAPP_MOCK_MODE:-true}
+      WHATSAPP_DEFAULT_TENANT_ID: ${WHATSAPP_DEFAULT_TENANT_ID:-}
+      WHATSAPP_DEFAULT_TENANT_NAME: ${WHATSAPP_DEFAULT_TENANT_NAME:-Default WhatsApp Tenant}
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    ports:
+      - "8000:8000"
+
+  migrate:
+    image: sais-api:latest
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg2://${POSTGRES_USER:-sais}:${POSTGRES_PASSWORD:-sais}@db:5432/${POSTGRES_DB:-sais}}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      TZ: ${TZ:-America/Fortaleza}
+    command: ["alembic", "upgrade", "head"]
+
+  worker:
+    build:
+      context: .
+      dockerfile: ops/docker/worker.Dockerfile
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg2://${POSTGRES_USER:-sais}:${POSTGRES_PASSWORD:-sais}@db:5432/${POSTGRES_DB:-sais}}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      TZ: ${TZ:-America/Fortaleza}
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+
+  web:
+    build:
+      context: .
+      dockerfile: ops/docker/web.Dockerfile
+    environment:
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8000}
+      TZ: ${TZ:-America/Fortaleza}
+    depends_on:
+      api:
+        condition: service_started
+    ports:
+      - "3000:3000"
+
+  nginx:
+    image: nginx:1.25-alpine
+    depends_on:
+      api:
+        condition: service_started
+      web:
+        condition: service_started
+    ports:
+      - "8080:80"
+    volumes:
+      - ./ops/docker/nginx.conf:/etc/nginx/nginx.conf:ro
+
+volumes:
+  db_data:
+  redis_data:

--- a/sais/jobs/app/__init__.py
+++ b/sais/jobs/app/__init__.py
@@ -1,0 +1,1 @@
+"""Celery worker application for SAIS."""

--- a/sais/jobs/app/celery_app.py
+++ b/sais/jobs/app/celery_app.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from celery import Celery
+
+from jobs.app.config import settings
+
+celery_app = Celery(
+    "sais",
+    broker=settings.redis_url,
+    backend=settings.redis_url,
+    include=["jobs.app.tasks"],
+)
+
+celery_app.conf.timezone = settings.timezone
+celery_app.conf.broker_connection_retry_on_startup = True

--- a/sais/jobs/app/config.py
+++ b/sais/jobs/app/config.py
@@ -1,0 +1,21 @@
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Celery worker configuration."""
+
+    redis_url: str = "redis://redis:6379/0"
+    timezone: str = "America/Fortaleza"
+    database_url: str = "postgresql+psycopg2://sais:sais@db:5432/sais"
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    return Settings()
+
+
+settings = get_settings()

--- a/sais/jobs/app/tasks.py
+++ b/sais/jobs/app/tasks.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from celery.utils.log import get_task_logger
+
+from jobs.app.celery_app import celery_app
+
+logger = get_task_logger(__name__)
+
+
+def _resolve_when(scheduled_start: str | None, delta: timedelta) -> datetime:
+    """Return the timestamp when a reminder should be dispatched."""
+
+    if scheduled_start:
+        try:
+            start = datetime.fromisoformat(scheduled_start)
+            return start - delta
+        except ValueError:
+            logger.warning("Invalid scheduled_start %s", scheduled_start)
+    return datetime.utcnow()
+
+
+def _emit_reminder(
+    *,
+    appointment_id: str,
+    window: str,
+    scheduled_start: str | None,
+    delta: timedelta,
+) -> dict[str, Any]:
+    eta = _resolve_when(scheduled_start, delta)
+    logger.info(
+        "Dispatching %s reminder for appointment %s at %s",
+        window,
+        appointment_id,
+        eta.isoformat(),
+    )
+    return {
+        "appointment_id": appointment_id,
+        "reminder_window": window,
+        "dispatch_at": eta.isoformat(),
+    }
+
+
+@celery_app.task(name="jobs.send_reminder_d2")
+def send_reminder_d2(
+    appointment_id: str, scheduled_start: str | None = None
+) -> dict[str, Any]:
+    """Send the D-2 reminder (two days before)."""
+
+    return _emit_reminder(
+        appointment_id=appointment_id,
+        window="D-2",
+        scheduled_start=scheduled_start,
+        delta=timedelta(days=2),
+    )
+
+
+@celery_app.task(name="jobs.send_reminder_d1")
+def send_reminder_d1(
+    appointment_id: str, scheduled_start: str | None = None
+) -> dict[str, Any]:
+    """Send the D-1 reminder (one day before)."""
+
+    return _emit_reminder(
+        appointment_id=appointment_id,
+        window="D-1",
+        scheduled_start=scheduled_start,
+        delta=timedelta(days=1),
+    )
+
+
+@celery_app.task(name="jobs.send_reminder_h2")
+def send_reminder_h2(
+    appointment_id: str, scheduled_start: str | None = None
+) -> dict[str, Any]:
+    """Send the H-2 reminder (two hours before)."""
+
+    return _emit_reminder(
+        appointment_id=appointment_id,
+        window="H-2",
+        scheduled_start=scheduled_start,
+        delta=timedelta(hours=2),
+    )
+
+
+@celery_app.task(name="jobs.flag_no_show")
+def flag_no_show(appointment_id: str) -> dict[str, Any]:
+    """Mark an appointment as a potential no-show for follow-up."""
+
+    follow_up = datetime.utcnow() + timedelta(hours=1)
+    logger.warning(
+        "Flagging appointment %s as potential no-show. Follow-up at %s",
+        appointment_id,
+        follow_up.isoformat(),
+    )
+    return {"appointment_id": appointment_id, "follow_up": follow_up.isoformat()}

--- a/sais/ops/Makefile
+++ b/sais/ops/Makefile
@@ -1,0 +1,18 @@
+COMPOSE_FILE ?= docker-compose.yml
+DOCKER_COMPOSE = docker compose -f $(COMPOSE_FILE)
+
+.PHONY: up down logs migrate seed
+up:
+$(DOCKER_COMPOSE) up -d --build
+
+down:
+$(DOCKER_COMPOSE) down
+
+logs:
+$(DOCKER_COMPOSE) logs -f
+
+migrate:
+$(DOCKER_COMPOSE) run --rm migrate
+
+seed:
+$(DOCKER_COMPOSE) run --rm api python -m app.seed

--- a/sais/ops/docker-compose.yml
+++ b/sais/ops/docker-compose.yml
@@ -1,0 +1,1 @@
+../docker-compose.yml

--- a/sais/ops/docker/api.Dockerfile
+++ b/sais/ops/docker/api.Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \ 
+    && apt-get install -y --no-install-recommends build-essential libpq-dev \ 
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY api/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY api /app
+ENV PYTHONPATH=/app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/sais/ops/docker/nginx.conf
+++ b/sais/ops/docker/nginx.conf
@@ -1,0 +1,27 @@
+events {}
+
+http {
+    upstream sais_web {
+        server web:3000;
+    }
+
+    upstream sais_api {
+        server api:8000;
+    }
+
+    server {
+        listen 80;
+
+        location /api/ {
+            proxy_pass http://sais_api/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location / {
+            proxy_pass http://sais_web/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+    }
+}

--- a/sais/ops/docker/web.Dockerfile
+++ b/sais/ops/docker/web.Dockerfile
@@ -1,0 +1,25 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY web/package.json ./
+COPY web/package-lock.json ./
+RUN npm ci
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+COPY --from=deps /app/node_modules ./node_modules
+COPY web/ ./
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/sais/ops/docker/worker.Dockerfile
+++ b/sais/ops/docker/worker.Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \ 
+    && apt-get install -y --no-install-recommends build-essential libpq-dev \ 
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY api/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY api /app/api
+COPY jobs /app/jobs
+ENV PYTHONPATH=/app
+
+CMD ["celery", "-A", "jobs.app.celery_app.celery_app", "worker", "--loglevel=info"]

--- a/sais/web/.eslintrc.json
+++ b/sais/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/sais/web/app/globals.css
+++ b/sais/web/app/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #f8fafc;
+  color: #0f172a;
+}

--- a/sais/web/app/layout.tsx
+++ b/sais/web/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { Providers } from "./providers";
+
+export const metadata: Metadata = {
+  title: "SAIS - Saúde Inteligente",
+  description: "Portal unificado para agendamentos e comunicação inteligente.",
+  metadataBase: new URL("https://example.com")
+};
+
+export default function RootLayout({
+  children
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="pt-BR">
+      <body className="min-h-screen bg-slate-50 text-slate-900">
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/sais/web/app/page.tsx
+++ b/sais/web/app/page.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+
+const stats = [
+  { label: "Pacientes atendidos", value: "+12k" },
+  { label: "Profissionais", value: "350" },
+  { label: "Taxa de no-show", value: "-32%" }
+];
+
+const benefits = [
+  {
+    title: "Menos faltas",
+    description: "Lembretes multicanal com confirmação automática reduzem o no-show e liberam encaixes com segurança."
+  },
+  {
+    title: "Agenda inteligente",
+    description: "Aplicamos buffers, bloqueios e preferências por profissional para garantir a melhor ocupação da equipe."
+  },
+  {
+    title: "Experiência humanizada",
+    description: "Crie jornadas personalizadas com mensagens no tom da clínica e encante pacientes em cada interação."
+  }
+];
+
+const steps = [
+  {
+    title: "Descoberta",
+    description: "Configuramos serviços, políticas de agendamento e integrações em poucos dias."
+  },
+  {
+    title: "Conexão",
+    description: "Importe pacientes ou ative formulários e bots para alimentar a base automaticamente."
+  },
+  {
+    title: "Engajamento",
+    description: "Fluxos inteligentes enviam convites, lembretes e pós-consulta no canal ideal."
+  },
+  {
+    title: "Análise",
+    description: "Dashboards atualizam KPIs em tempo real para decisões orientadas por dados."
+  }
+];
+
+const features = [
+  {
+    title: "Orquestração Omnicanal",
+    description: "WhatsApp, SMS, e-mail e telefone atuando em sincronia com regras de 24h e templates aprovados."
+  },
+  {
+    title: "Fila inteligente",
+    description: "Encaixes automáticos com priorização por urgência e preferências do paciente."
+  },
+  {
+    title: "Relatórios acionáveis",
+    description: "KPIs de ocupação, no-show, receita e engajamento com exportação em um clique."
+  },
+  {
+    title: "Portal do paciente",
+    description: "Autoatendimento, confirmação em um toque e histórico sempre disponível."
+  },
+  {
+    title: "Integrações",
+    description: "API aberta para ERPs odontológicos, pagamentos e soluções de telemedicina."
+  },
+  {
+    title: "Suporte estratégico",
+    description: "Time especialista acompanha sua operação para capturar oportunidades."
+  }
+];
+
+const plans = [
+  {
+    name: "Essencial",
+    price: "R$ 799/mês",
+    items: ["Até 3 cadeiras", "Templates e fluxos prontos", "Portal paciente"],
+    highlight: false
+  },
+  {
+    name: "Growth",
+    price: "R$ 1.299/mês",
+    items: ["Até 6 cadeiras", "WhatsApp oficial incluso", "Dashboard de ocupação"],
+    highlight: true
+  },
+  {
+    name: "Enterprise",
+    price: "Sob consulta",
+    items: ["Multiclínicas", "Suporte dedicado", "Integrações personalizadas"],
+    highlight: false
+  }
+];
+
+const testimonials = [
+  {
+    name: "Dra. Fernanda Azevedo",
+    role: "CEO · Rede Sorrir",
+    quote: "Reduzimos no-show em 41% no primeiro trimestre com lembretes omnichannel e confirmação pelo bot."
+  },
+  {
+    name: "Marcelo Andrade",
+    role: "Diretor Operacional · A1 Odonto",
+    quote: "O time ganhou visibilidade do dia e consegue reagir rápido a encaixes sem planilhas paralelas."
+  },
+  {
+    name: "Paula Meireles",
+    role: "Coordenadora de Atendimento · Studio Odonto",
+    quote: "A jornada pós-consulta elevou nosso NPS para 92 e impulsionou indicações orgânicas."
+  }
+];
+
+const faqs = [
+  {
+    question: "Quanto tempo leva para ativar o SAIS?",
+    answer: "Em até 7 dias configuramos serviços, profissionais, templates e conectamos seu número oficial."
+  },
+  {
+    question: "Posso usar meu WhatsApp atual?",
+    answer: "Sim, basta validar o número na Evolution e conectamos o bot de atendimento sem perder histórico."
+  },
+  {
+    question: "Como funciona a cobrança?",
+    answer: "Planos mensais com contratação flexível, sem fidelidade. Créditos de mensagens são ajustados ao volume."
+  },
+  {
+    question: "É necessário treinamento?",
+    answer: "Disponibilizamos onboarding remoto e materiais sob demanda. Sua equipe domina o portal em horas."
+  }
+];
+
+export default function LandingPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gradient-to-b from-white via-slate-50 to-slate-100 text-slate-900">
+      <section className="relative w-full overflow-hidden px-6 pt-24 pb-16 sm:px-12 lg:px-24">
+        <div className="mx-auto grid max-w-6xl gap-16 lg:grid-cols-2 lg:items-center">
+          <motion.div
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, ease: "easeOut" }}
+            className="space-y-8"
+          >
+            <span className="inline-flex items-center rounded-full bg-brand/10 px-4 py-1 text-sm font-medium text-brand">
+              Plataforma omnichannel para saúde inteligente
+            </span>
+            <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+              Centralize agendamentos, mensagens e performance da sua clínica em um só lugar.
+            </h1>
+            <p className="text-lg text-slate-600">
+              O SAIS conecta sua clínica a pacientes com fluxos automatizados, lembretes inteligentes e painéis de performance
+              para reduzir faltas e aumentar a satisfação.
+            </p>
+            <div className="flex flex-wrap items-center gap-4">
+              <motion.div whileHover={{ scale: 1.04 }} whileTap={{ scale: 0.98 }}>
+                <Link
+                  href="/portal"
+                  className="rounded-full bg-brand px-6 py-3 text-base font-semibold text-white shadow-lg shadow-brand/40 transition hover:bg-brand-dark"
+                >
+                  Acessar Portal do Paciente
+                </Link>
+              </motion.div>
+              <motion.div whileHover={{ scale: 1.04 }} whileTap={{ scale: 0.98 }}>
+                <a
+                  href="#planos"
+                  className="rounded-full border border-brand px-6 py-3 text-base font-semibold text-brand transition hover:border-brand-dark hover:text-brand-dark"
+                >
+                  Ver planos
+                </a>
+              </motion.div>
+            </div>
+            <dl className="grid gap-6 sm:grid-cols-3">
+              {stats.map((stat) => (
+                <div key={stat.label} className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+                  <dt className="text-sm font-medium text-slate-500">{stat.label}</dt>
+                  <dd className="mt-2 text-3xl font-semibold text-slate-900">{stat.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, x: 60 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.9, ease: "easeOut", delay: 0.2 }}
+            className="relative"
+          >
+            <div className="relative mx-auto max-w-md overflow-hidden rounded-3xl bg-white p-6 shadow-xl ring-1 ring-slate-900/5">
+              <div className="space-y-4">
+                <h2 className="text-lg font-semibold">Jornada do paciente</h2>
+                <p className="text-sm text-slate-500">
+                  Monitoramento em tempo real com alertas automáticos, notificações multicanal e visão 360º do histórico do
+                  paciente.
+                </p>
+                <ul className="space-y-3 text-sm">
+                  <li className="flex items-start gap-2">
+                    <span className="mt-1 h-2.5 w-2.5 rounded-full bg-emerald-400" />
+                    <span>Lembretes com confirmação por WhatsApp, SMS e e-mail.</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-1 h-2.5 w-2.5 rounded-full bg-sky-400" />
+                    <span>Painel de ocupação com previsão baseada em machine learning.</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-1 h-2.5 w-2.5 rounded-full bg-violet-400" />
+                    <span>Check-in digital e automação de pós-consulta.</span>
+                  </li>
+                </ul>
+              </div>
+              <div className="mt-8 rounded-2xl bg-slate-900 px-6 py-5 text-white">
+                <p className="text-sm uppercase tracking-wide text-slate-300">Taxa de confirmação</p>
+                <p className="mt-2 text-4xl font-bold">92%</p>
+                <p className="mt-1 text-sm text-slate-300">+18% vs. média do mercado</p>
+              </div>
+            </div>
+            <div className="absolute inset-0 -z-10 rounded-full bg-brand/20 blur-3xl" aria-hidden />
+          </motion.div>
+        </div>
+      </section>
+
+      <motion.section
+        initial={{ opacity: 0, y: 32 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, amount: 0.3 }}
+        transition={{ duration: 0.6 }}
+        className="w-full bg-white py-16"
+      >
+        <div className="mx-auto max-w-5xl space-y-10 px-6 sm:px-12">
+          <div className="text-center">
+            <p className="text-xs uppercase tracking-[0.32em] text-brand">Benefícios</p>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-900">Resultados tangíveis em semanas</h2>
+          </div>
+          <div className="grid gap-6 md:grid-cols-3">
+            {benefits.map((benefit) => (
+              <motion.article
+                key={benefit.title}
+                whileHover={{ translateY: -6 }}
+                className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+              >
+                <h3 className="text-xl font-semibold text-slate-900">{benefit.title}</h3>
+                <p className="mt-3 text-sm text-slate-600">{benefit.description}</p>
+              </motion.article>
+            ))}
+          </div>
+        </div>
+      </motion.section>
+
+      <motion.section
+        initial={{ opacity: 0, y: 32 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, amount: 0.4 }}
+        transition={{ duration: 0.6 }}
+        className="w-full bg-slate-50 py-16"
+      >
+        <div className="mx-auto max-w-5xl space-y-8 px-6 sm:px-12">
+          <div className="text-center">
+            <p className="text-xs uppercase tracking-[0.32em] text-brand">Como funciona</p>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-900">Fluxo rápido da implantação</h2>
+          </div>
+          <div className="grid gap-6 md:grid-cols-4">
+            {steps.map((step, index) => (
+              <div key={step.title} className="space-y-3 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-brand/10 text-sm font-semibold text-brand">
+                  {index + 1}
+                </span>
+                <h3 className="text-lg font-semibold text-slate-900">{step.title}</h3>
+                <p className="text-sm text-slate-600">{step.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </motion.section>
+
+      <motion.section
+        initial={{ opacity: 0, y: 32 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, amount: 0.3 }}
+        transition={{ duration: 0.6 }}
+        className="w-full bg-white py-16"
+      >
+        <div className="mx-auto max-w-6xl space-y-8 px-6 sm:px-12">
+          <div className="text-center">
+            <p className="text-xs uppercase tracking-[0.32em] text-brand">Recursos</p>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-900">Tecnologia pensada para operações de saúde</h2>
+          </div>
+          <div className="grid gap-6 md:grid-cols-3">
+            {features.map((feature) => (
+              <motion.article
+                key={feature.title}
+                whileHover={{ translateY: -4 }}
+                className="rounded-3xl border border-slate-200 bg-white p-6 text-left shadow-sm"
+              >
+                <h3 className="text-lg font-semibold text-slate-900">{feature.title}</h3>
+                <p className="mt-3 text-sm text-slate-600">{feature.description}</p>
+              </motion.article>
+            ))}
+          </div>
+        </div>
+      </motion.section>
+
+      <motion.section
+        id="planos"
+        initial={{ opacity: 0, y: 32 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, amount: 0.3 }}
+        transition={{ duration: 0.6 }}
+        className="w-full bg-slate-50 py-16"
+      >
+        <div className="mx-auto max-w-6xl space-y-8 px-6 sm:px-12">
+          <div className="text-center">
+            <p className="text-xs uppercase tracking-[0.32em] text-brand">Planos</p>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-900">Escolha o formato ideal para sua operação</h2>
+          </div>
+          <div className="grid gap-6 md:grid-cols-3">
+            {plans.map((plan) => (
+              <motion.article
+                key={plan.name}
+                whileHover={{ translateY: -6 }}
+                className={`rounded-3xl border p-6 text-center shadow-sm ${
+                  plan.highlight ? "border-brand bg-white" : "border-slate-200 bg-white"
+                }`}
+              >
+                <p className="text-xs uppercase tracking-[0.32em] text-brand">{plan.name}</p>
+                <p className="mt-3 text-3xl font-semibold text-slate-900">{plan.price}</p>
+                <ul className="mt-4 space-y-2 text-sm text-slate-600">
+                  {plan.items.map((item) => (
+                    <li key={item}>• {item}</li>
+                  ))}
+                </ul>
+                <motion.a
+                  whileHover={{ scale: 1.03 }}
+                  whileTap={{ scale: 0.97 }}
+                  href="https://wa.me/5585988887777?text=Quero%20conhecer%20o%20SAIS"
+                  className={`mt-6 inline-flex w-full justify-center rounded-full px-5 py-2 text-sm font-semibold transition ${
+                    plan.highlight ? "bg-brand text-white" : "border border-brand text-brand"
+                  }`}
+                >
+                  Falar com especialista
+                </motion.a>
+              </motion.article>
+            ))}
+          </div>
+        </div>
+      </motion.section>
+
+      <motion.section
+        initial={{ opacity: 0, y: 32 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, amount: 0.3 }}
+        transition={{ duration: 0.6 }}
+        className="w-full bg-white py-16"
+      >
+        <div className="mx-auto max-w-5xl space-y-8 px-6 sm:px-12">
+          <div className="text-center">
+            <p className="text-xs uppercase tracking-[0.32em] text-brand">Depoimentos</p>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-900">Clínicas que já aceleram com o SAIS</h2>
+          </div>
+          <div className="grid gap-6 md:grid-cols-3">
+            {testimonials.map((testimonial) => (
+              <motion.blockquote
+                key={testimonial.name}
+                whileHover={{ translateY: -4 }}
+                className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+              >
+                <p className="text-sm text-slate-600">“{testimonial.quote}”</p>
+                <footer className="mt-4 text-sm font-semibold text-slate-900">
+                  {testimonial.name}
+                  <span className="block text-xs font-normal text-slate-500">{testimonial.role}</span>
+                </footer>
+              </motion.blockquote>
+            ))}
+          </div>
+        </div>
+      </motion.section>
+
+      <motion.section
+        initial={{ opacity: 0, y: 32 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, amount: 0.3 }}
+        transition={{ duration: 0.6 }}
+        className="w-full bg-slate-50 py-16"
+      >
+        <div className="mx-auto max-w-4xl space-y-6 px-6 sm:px-12">
+          <div className="text-center">
+            <p className="text-xs uppercase tracking-[0.32em] text-brand">FAQ</p>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-900">Perguntas frequentes</h2>
+          </div>
+          <div className="space-y-4">
+            {faqs.map((faq) => (
+              <details key={faq.question} className="rounded-3xl border border-slate-200 bg-white p-6 text-left shadow-sm">
+                <summary className="cursor-pointer text-lg font-semibold text-slate-900">
+                  {faq.question}
+                </summary>
+                <p className="mt-3 text-sm text-slate-600">{faq.answer}</p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </motion.section>
+
+      <motion.section
+        initial={{ opacity: 0, y: 32 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, amount: 0.3 }}
+        transition={{ duration: 0.6 }}
+        className="w-full bg-white py-20"
+      >
+        <div className="mx-auto flex max-w-3xl flex-col items-center gap-6 px-6 text-center sm:px-12">
+          <h2 className="text-3xl font-semibold text-slate-900">Pronto para transformar a jornada dos pacientes?</h2>
+          <p className="text-sm text-slate-600">
+            Fale com nosso time pelo WhatsApp e descubra como o SAIS pode personalizar a operação para sua clínica.
+          </p>
+          <motion.a
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+            href="https://wa.me/5585988887777?text=Quero%20conhecer%20o%20SAIS"
+            className="inline-flex items-center gap-2 rounded-full bg-emerald-500 px-8 py-3 text-base font-semibold text-white shadow-lg shadow-emerald-500/40"
+          >
+            <span>Enviar mensagem no WhatsApp</span>
+            <span aria-hidden>→</span>
+          </motion.a>
+        </div>
+      </motion.section>
+    </main>
+  );
+}

--- a/sais/web/app/portal/agenda/page.tsx
+++ b/sais/web/app/portal/agenda/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScheduleBoard } from "../../../components/schedule-board";
+
+export default function AgendaPage() {
+  return <ScheduleBoard />;
+}

--- a/sais/web/app/portal/layout.tsx
+++ b/sais/web/app/portal/layout.tsx
@@ -1,0 +1,5 @@
+import PortalShell from "../../components/portal-shell";
+
+export default function PortalLayout({ children }: { children: React.ReactNode }) {
+  return <PortalShell>{children}</PortalShell>;
+}

--- a/sais/web/app/portal/pacientes/page.tsx
+++ b/sais/web/app/portal/pacientes/page.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import { motion } from "framer-motion";
+
+import { RoleGuard } from "../../../components/role-guard";
+
+type Patient = {
+  id: string;
+  name: string;
+  phone: string;
+  lastVisit: string;
+  tags: string[];
+  notes?: string;
+};
+
+const initialPatients: Patient[] = [
+  {
+    id: "p-1",
+    name: "Larissa Monteiro",
+    phone: "+55 85 98888-1234",
+    lastVisit: "12/03/2024",
+    tags: ["Ortodontia", "VIP"],
+    notes: "Prefere contato por WhatsApp."
+  },
+  {
+    id: "p-2",
+    name: "Daniel Furtado",
+    phone: "+55 85 99777-4321",
+    lastVisit: "04/04/2024",
+    tags: ["Implante"],
+    notes: "Enviar lembrete com instruções pré-cirúrgicas."
+  }
+];
+
+export default function PatientsPage() {
+  return (
+    <RoleGuard
+      allowed={["owner", "manager", "reception"]}
+      fallback={
+        <div className="rounded-3xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-700">
+          Acesso restrito: somente a recepção e gestão podem editar cadastros de pacientes.
+        </div>
+      }
+    >
+      <PatientsManager />
+    </RoleGuard>
+  );
+}
+
+function PatientsManager() {
+  const [patients, setPatients] = useState<Patient[]>(initialPatients);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [form, setForm] = useState({ name: "", phone: "", tags: "", notes: "" });
+
+  const filteredPatients = useMemo(() => {
+    if (!search) return patients;
+    const query = search.toLowerCase();
+    return patients.filter((patient) =>
+      [patient.name, patient.phone, patient.tags.join(","), patient.notes ?? ""].some((field) =>
+        field.toLowerCase().includes(query)
+      )
+    );
+  }, [patients, search]);
+
+  const resetForm = () => {
+    setForm({ name: "", phone: "", tags: "", notes: "" });
+    setEditing(null);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const payload: Patient = {
+      id: editing ?? `p-${Date.now()}`,
+      name: form.name,
+      phone: form.phone,
+      lastVisit: editing ? patients.find((item) => item.id === editing)?.lastVisit ?? "--" : "--",
+      tags: form.tags
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter(Boolean),
+      notes: form.notes
+    };
+
+    if (editing) {
+      setPatients((prev) => prev.map((item) => (item.id === editing ? { ...payload } : item)));
+    } else {
+      setPatients((prev) => [{ ...payload, lastVisit: "--" }, ...prev]);
+    }
+    resetForm();
+  };
+
+  const startEdit = (patient: Patient) => {
+    setEditing(patient.id);
+    setForm({
+      name: patient.name,
+      phone: patient.phone,
+      tags: patient.tags.join(", "),
+      notes: patient.notes ?? ""
+    });
+  };
+
+  const removePatient = (id: string) => {
+    setPatients((prev) => prev.filter((patient) => patient.id !== id));
+    if (editing === id) {
+      resetForm();
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2">
+        <span className="text-xs uppercase tracking-[0.32em] text-brand">Pacientes</span>
+        <h1 className="text-3xl font-semibold text-slate-900">Centralize cadastros e contatos</h1>
+        <p className="text-sm text-slate-500">
+          Cadastre novos pacientes, atualize preferências de comunicação e mantenha a equipe alinhada com históricos.
+        </p>
+      </header>
+
+      <motion.form
+        onSubmit={handleSubmit}
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="text-sm font-medium text-slate-600">
+            Nome completo
+            <input
+              required
+              value={form.name}
+              onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-brand focus:outline-none"
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-600">
+            Telefone
+            <input
+              required
+              value={form.phone}
+              onChange={(event) => setForm((prev) => ({ ...prev, phone: event.target.value }))}
+              placeholder="+55 85 9XXXX-XXXX"
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-brand focus:outline-none"
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-600">
+            Tags
+            <input
+              value={form.tags}
+              onChange={(event) => setForm((prev) => ({ ...prev, tags: event.target.value }))}
+              placeholder="Implante, VIP"
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-brand focus:outline-none"
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-600 md:col-span-2">
+            Observações
+            <textarea
+              value={form.notes}
+              onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
+              rows={3}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-brand focus:outline-none"
+            />
+          </label>
+        </div>
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <motion.button
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            type="submit"
+            className="rounded-full bg-brand px-5 py-2 text-sm font-semibold text-white shadow-brand/40"
+          >
+            {editing ? "Atualizar paciente" : "Adicionar paciente"}
+          </motion.button>
+          {editing && (
+            <button
+              type="button"
+              onClick={resetForm}
+              className="text-sm font-medium text-slate-500 underline"
+            >
+              Cancelar edição
+            </button>
+          )}
+        </div>
+      </motion.form>
+
+      <section className="space-y-4">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">Pacientes ativos</h2>
+          <input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Buscar por nome, telefone ou tag"
+            className="w-full rounded-full border border-slate-200 bg-white px-4 py-2 text-sm focus:border-brand focus:outline-none md:w-72"
+          />
+        </div>
+        <div className="space-y-3">
+          {filteredPatients.map((patient) => (
+            <motion.article
+              key={patient.id}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="flex flex-col gap-3 rounded-3xl border border-slate-200 bg-white/80 p-5 shadow-sm md:flex-row md:items-center md:justify-between"
+            >
+              <div>
+                <p className="text-lg font-semibold text-slate-900">{patient.name}</p>
+                <p className="text-sm text-slate-500">{patient.phone}</p>
+                <p className="text-xs text-slate-400">Última visita: {patient.lastVisit}</p>
+                <div className="mt-2 flex flex-wrap gap-2 text-xs text-brand">
+                  {patient.tags.map((tag) => (
+                    <span key={tag} className="rounded-full bg-brand/10 px-3 py-1 font-semibold">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                {patient.notes && <p className="mt-2 text-xs text-slate-500">{patient.notes}</p>}
+              </div>
+              <div className="flex gap-2 text-sm">
+                <motion.button
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
+                  onClick={() => startEdit(patient)}
+                  className="rounded-full border border-brand px-4 py-2 font-semibold text-brand"
+                >
+                  Editar
+                </motion.button>
+                <motion.button
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
+                  onClick={() => removePatient(patient.id)}
+                  className="rounded-full border border-red-200 px-4 py-2 font-semibold text-red-500"
+                >
+                  Remover
+                </motion.button>
+              </div>
+            </motion.article>
+          ))}
+          {filteredPatients.length === 0 && (
+            <p className="rounded-3xl border border-dashed border-slate-200 bg-white py-8 text-center text-sm text-slate-400">
+              Nenhum paciente encontrado com esse filtro.
+            </p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/sais/web/app/portal/page.tsx
+++ b/sais/web/app/portal/page.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+import { RoleGuard } from "../../components/role-guard";
+
+const metrics = [
+  {
+    title: "Ocupação",
+    value: "82%",
+    delta: "+6%",
+    description: "vs. semana anterior",
+    roles: ["owner", "manager", "reception"],
+    tone: "positive"
+  },
+  {
+    title: "No-show",
+    value: "4,5%",
+    delta: "-2,1%",
+    description: "com lembretes automáticos",
+    roles: ["owner", "manager", "reception"],
+    tone: "positive"
+  },
+  {
+    title: "Satisfação (NPS)",
+    value: "92",
+    delta: "+12",
+    description: "respostas pós-consulta",
+    roles: ["owner", "manager"],
+    tone: "positive"
+  }
+] as const;
+
+const timeline = [
+  { time: "08:30", patient: "Juliana Castro", service: "Avaliação", status: "Confirmado" },
+  { time: "10:00", patient: "Rodrigo Lopes", service: "Limpeza", status: "Aguardando confirmação" },
+  { time: "13:30", patient: "Bianca Prado", service: "Clareamento", status: "Check-in realizado" },
+  { time: "16:00", patient: "Felipe Neves", service: "Manutenção ortodôntica", status: "Lembrete enviado" }
+];
+
+const automationHighlights = [
+  {
+    title: "Fluxos ativos",
+    detail: "9 campanhas",
+    caption: "Lembretes, pós-consulta e reativações",
+    tone: "active"
+  },
+  {
+    title: "Mensagens enviadas",
+    detail: "1.284",
+    caption: "Últimos 30 dias",
+    tone: "neutral"
+  },
+  {
+    title: "Conversões WhatsApp",
+    detail: "37%",
+    caption: "Agendamentos confirmados via bot",
+    tone: "positive"
+  }
+];
+
+export default function PortalPage() {
+  return (
+    <div className="space-y-8">
+      <motion.header
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        className="flex flex-col gap-2"
+      >
+        <span className="text-xs uppercase tracking-[0.32em] text-brand">Visão geral</span>
+        <h1 className="text-3xl font-semibold text-slate-900">Como está a operação hoje?</h1>
+        <p className="text-sm text-slate-500">
+          Analise indicadores em tempo real, antecipe picos de atendimento e garanta que a equipe esteja alinhada com a agenda
+          inteligente.
+        </p>
+      </motion.header>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        {metrics.map((metric, index) => (
+          <RoleGuard
+            key={metric.title}
+            allowed={metric.roles}
+            fallback={
+              <motion.div
+                initial={{ opacity: 0, y: 16 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.1 * index }}
+                className="rounded-3xl border border-dashed border-slate-200 bg-white/60 p-6 text-sm text-slate-400"
+              >
+                Métrica disponível somente para gestão.
+              </motion.div>
+            }
+          >
+            <motion.article
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.1 * index }}
+              className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+            >
+              <header className="flex items-center justify-between text-xs uppercase text-slate-500">
+                <span>{metric.title}</span>
+                <span
+                  className={`rounded-full px-3 py-1 text-[11px] font-semibold ${
+                    metric.tone === "positive" ? "bg-emerald-100 text-emerald-700" : "bg-slate-100 text-slate-600"
+                  }`}
+                >
+                  {metric.delta}
+                </span>
+              </header>
+              <p className="mt-4 text-3xl font-semibold text-slate-900">{metric.value}</p>
+              <p className="mt-2 text-sm text-slate-500">{metric.description}</p>
+            </motion.article>
+          </RoleGuard>
+        ))}
+      </section>
+
+      <motion.section
+        initial={{ opacity: 0, y: 24 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, delay: 0.2 }}
+        className="grid gap-6 lg:grid-cols-[2fr_1fr]"
+      >
+        <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-slate-900">Agenda do dia</h2>
+              <p className="text-sm text-slate-500">Monitoramento em tempo real com confirmações automáticas.</p>
+            </div>
+            <span className="rounded-full bg-brand/10 px-3 py-1 text-xs font-semibold text-brand">12 consultas</span>
+          </div>
+          <ol className="mt-6 space-y-4 text-sm text-slate-600">
+            {timeline.map((item) => (
+              <li
+                key={item.patient}
+                className="flex items-start gap-4 rounded-2xl border border-slate-100 bg-slate-50/60 p-4"
+              >
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-sm font-semibold text-brand">
+                  {item.time}
+                </div>
+                <div>
+                  <p className="font-semibold text-slate-900">{item.patient}</p>
+                  <p className="text-xs text-slate-500">{item.service}</p>
+                  <p className="mt-1 inline-flex rounded-full bg-emerald-100 px-2 py-1 text-[11px] font-medium text-emerald-700">
+                    {item.status}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </article>
+        <aside className="space-y-4">
+          {automationHighlights.map((highlight, index) => (
+            <motion.div
+              key={highlight.title}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.15 * index }}
+              className={`rounded-3xl border p-5 shadow-sm ${
+                highlight.tone === "positive"
+                  ? "border-emerald-200 bg-emerald-50"
+                  : highlight.tone === "active"
+                  ? "border-brand/40 bg-brand/10"
+                  : "border-slate-200 bg-white"
+              }`}
+            >
+              <p className="text-xs uppercase tracking-wide text-slate-500">{highlight.title}</p>
+              <p className="mt-2 text-2xl font-semibold text-slate-900">{highlight.detail}</p>
+              <p className="mt-1 text-xs text-slate-600">{highlight.caption}</p>
+            </motion.div>
+          ))}
+        </aside>
+      </motion.section>
+
+      <motion.section
+        initial={{ opacity: 0, y: 24 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, delay: 0.3 }}
+        className="grid gap-6 md:grid-cols-2"
+      >
+        <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-xl font-semibold text-slate-900">Fila de mensagens</h2>
+          <p className="mt-2 text-sm text-slate-500">
+            Mensagens humanizadas disparadas automaticamente conforme o status da jornada do paciente.
+          </p>
+          <ul className="mt-4 space-y-3 text-sm text-slate-600">
+            <li className="flex items-center justify-between rounded-2xl bg-slate-50 px-4 py-3">
+              <span>WhatsApp · Confirmação D-1</span>
+              <span className="text-xs font-semibold text-emerald-600">32 enviadas</span>
+            </li>
+            <li className="flex items-center justify-between rounded-2xl bg-slate-50 px-4 py-3">
+              <span>SMS · Reforço D-0</span>
+              <span className="text-xs font-semibold text-brand">9 agendadas</span>
+            </li>
+            <li className="flex items-center justify-between rounded-2xl bg-slate-50 px-4 py-3">
+              <span>E-mail · Pós-consulta NPS</span>
+              <span className="text-xs font-semibold text-slate-500">41 respostas</span>
+            </li>
+          </ul>
+        </article>
+        <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-xl font-semibold text-slate-900">Pendências da equipe</h2>
+          <ul className="mt-4 space-y-3 text-sm text-slate-600">
+            <li className="flex items-center justify-between rounded-2xl bg-amber-50 px-4 py-3 text-amber-700">
+              <span>Confirmar encaixe da paciente Larissa (18h)</span>
+              <button className="text-xs font-semibold uppercase tracking-wide">Resolver</button>
+            </li>
+            <li className="flex items-center justify-between rounded-2xl bg-white px-4 py-3">
+              <span>Enviar orientações pré-cirúrgicas para Daniel</span>
+              <button className="text-xs font-semibold text-brand">Enviar agora</button>
+            </li>
+            <li className="flex items-center justify-between rounded-2xl bg-white px-4 py-3">
+              <span>Registrar retorno de tratamento ortodôntico</span>
+              <button className="text-xs font-semibold text-brand">Abrir ficha</button>
+            </li>
+          </ul>
+        </article>
+      </motion.section>
+    </div>
+  );
+}

--- a/sais/web/app/portal/servicos/page.tsx
+++ b/sais/web/app/portal/servicos/page.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import { motion } from "framer-motion";
+
+import { RoleGuard } from "../../../components/role-guard";
+
+type Service = {
+  id: string;
+  name: string;
+  duration: number;
+  price: number;
+  buffer: number;
+};
+
+const initialServices: Service[] = [
+  { id: "s-1", name: "Consulta de avaliação", duration: 40, price: 180, buffer: 10 },
+  { id: "s-2", name: "Limpeza preventiva", duration: 50, price: 220, buffer: 5 },
+  { id: "s-3", name: "Clareamento consultório", duration: 90, price: 680, buffer: 15 }
+];
+
+const currency = new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" });
+
+export default function ServicesPage() {
+  return (
+    <RoleGuard
+      allowed={["owner", "manager"]}
+      fallback={
+        <div className="rounded-3xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-700">
+          Somente gestão pode editar os serviços ofertados. Consulte o responsável para solicitar alterações.
+        </div>
+      }
+    >
+      <ServicesManager />
+    </RoleGuard>
+  );
+}
+
+function ServicesManager() {
+  const [services, setServices] = useState<Service[]>(initialServices);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [form, setForm] = useState({ name: "", duration: 30, price: 150, buffer: 5 });
+  const [search, setSearch] = useState("");
+
+  const filteredServices = useMemo(() => {
+    if (!search) return services;
+    const query = search.toLowerCase();
+    return services.filter((service) => service.name.toLowerCase().includes(query));
+  }, [search, services]);
+
+  const reset = () => {
+    setForm({ name: "", duration: 30, price: 150, buffer: 5 });
+    setEditing(null);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const payload: Service = {
+      id: editing ?? `s-${Date.now()}`,
+      name: form.name,
+      duration: Number(form.duration),
+      price: Number(form.price),
+      buffer: Number(form.buffer)
+    };
+
+    if (editing) {
+      setServices((prev) => prev.map((service) => (service.id === editing ? payload : service)));
+    } else {
+      setServices((prev) => [payload, ...prev]);
+    }
+
+    reset();
+  };
+
+  const startEdit = (service: Service) => {
+    setEditing(service.id);
+    setForm({ name: service.name, duration: service.duration, price: service.price, buffer: service.buffer });
+  };
+
+  const removeService = (id: string) => {
+    setServices((prev) => prev.filter((service) => service.id !== id));
+    if (editing === id) {
+      reset();
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2">
+        <span className="text-xs uppercase tracking-[0.32em] text-brand">Serviços</span>
+        <h1 className="text-3xl font-semibold text-slate-900">Defina regras inteligentes por procedimento</h1>
+        <p className="text-sm text-slate-500">
+          Configure duração, buffers obrigatórios e precificação para otimizar a agenda com base em tipos de procedimentos.
+        </p>
+      </header>
+
+      <motion.form
+        onSubmit={handleSubmit}
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+      >
+        <div className="grid gap-4 md:grid-cols-4">
+          <label className="md:col-span-2 text-sm font-medium text-slate-600">
+            Nome do serviço
+            <input
+              required
+              value={form.name}
+              onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-brand focus:outline-none"
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-600">
+            Duração (min)
+            <input
+              type="number"
+              min={15}
+              value={form.duration}
+              onChange={(event) => setForm((prev) => ({ ...prev, duration: Number(event.target.value) }))}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-brand focus:outline-none"
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-600">
+            Buffer (min)
+            <input
+              type="number"
+              min={0}
+              value={form.buffer}
+              onChange={(event) => setForm((prev) => ({ ...prev, buffer: Number(event.target.value) }))}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-brand focus:outline-none"
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-600">
+            Preço (R$)
+            <input
+              type="number"
+              min={0}
+              step={10}
+              value={form.price}
+              onChange={(event) => setForm((prev) => ({ ...prev, price: Number(event.target.value) }))}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-brand focus:outline-none"
+            />
+          </label>
+        </div>
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <motion.button
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            type="submit"
+            className="rounded-full bg-brand px-5 py-2 text-sm font-semibold text-white shadow-brand/40"
+          >
+            {editing ? "Atualizar serviço" : "Adicionar serviço"}
+          </motion.button>
+          {editing && (
+            <button type="button" onClick={reset} className="text-sm font-medium text-slate-500 underline">
+              Cancelar edição
+            </button>
+          )}
+        </div>
+      </motion.form>
+
+      <section className="space-y-4">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">Tabela de serviços</h2>
+          <input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Buscar serviço"
+            className="w-full rounded-full border border-slate-200 bg-white px-4 py-2 text-sm focus:border-brand focus:outline-none md:w-64"
+          />
+        </div>
+        <div className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <tr>
+                <th className="px-6 py-4">Serviço</th>
+                <th className="px-6 py-4">Duração</th>
+                <th className="px-6 py-4">Buffer</th>
+                <th className="px-6 py-4">Preço</th>
+                <th className="px-6 py-4 text-right">Ações</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 bg-white">
+              {filteredServices.map((service) => (
+                <tr key={service.id} className="transition hover:bg-slate-50/80">
+                  <td className="px-6 py-4 font-semibold text-slate-900">{service.name}</td>
+                  <td className="px-6 py-4 text-slate-500">{service.duration} min</td>
+                  <td className="px-6 py-4 text-slate-500">{service.buffer} min</td>
+                  <td className="px-6 py-4 text-slate-500">{currency.format(service.price)}</td>
+                  <td className="px-6 py-4">
+                    <div className="flex justify-end gap-2">
+                      <motion.button
+                        whileHover={{ scale: 1.05 }}
+                        whileTap={{ scale: 0.95 }}
+                        onClick={() => startEdit(service)}
+                        className="rounded-full border border-brand px-4 py-2 text-xs font-semibold text-brand"
+                      >
+                        Editar
+                      </motion.button>
+                      <motion.button
+                        whileHover={{ scale: 1.05 }}
+                        whileTap={{ scale: 0.95 }}
+                        onClick={() => removeService(service.id)}
+                        className="rounded-full border border-red-200 px-4 py-2 text-xs font-semibold text-red-500"
+                      >
+                        Remover
+                      </motion.button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {filteredServices.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="px-6 py-10 text-center text-sm text-slate-400">
+                    Nenhum serviço encontrado com esse termo.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/sais/web/app/portal/templates/page.tsx
+++ b/sais/web/app/portal/templates/page.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import { motion } from "framer-motion";
+
+import { RoleGuard } from "../../../components/role-guard";
+
+type Template = {
+  id: string;
+  name: string;
+  channel: "WhatsApp" | "SMS" | "E-mail";
+  category: string;
+  body: string;
+  active: boolean;
+};
+
+const initialTemplates: Template[] = [
+  {
+    id: "t-1",
+    name: "Confirmação D-1",
+    channel: "WhatsApp",
+    category: "Lembrete",
+    body: "Olá {{nome}}, confirmamos sua consulta amanhã às {{horario}}. Responda 1 para confirmar ou 2 para remarcar.",
+    active: true
+  },
+  {
+    id: "t-2",
+    name: "Pós-consulta NPS",
+    channel: "WhatsApp",
+    category: "Pesquisa",
+    body: "Obrigado por confiar na clínica, {{nome}}! De 0 a 10, qual a chance de indicar nossos serviços?",
+    active: true
+  },
+  {
+    id: "t-3",
+    name: "Reativação",
+    channel: "E-mail",
+    category: "Follow-up",
+    body: "Sentimos sua falta, {{nome}}! Agende uma avaliação de revisão com condições especiais este mês.",
+    active: false
+  }
+];
+
+const channelOptions: Template["channel"][] = ["WhatsApp", "SMS", "E-mail"];
+
+export default function TemplatesPage() {
+  return (
+    <RoleGuard
+      allowed={["owner", "manager", "reception"]}
+      fallback={
+        <div className="rounded-3xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-700">
+          Apenas a recepção e gestão podem editar templates transacionais.
+        </div>
+      }
+    >
+      <TemplatesManager />
+    </RoleGuard>
+  );
+}
+
+function TemplatesManager() {
+  const [templates, setTemplates] = useState<Template[]>(initialTemplates);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [form, setForm] = useState({ name: "", channel: channelOptions[0], category: "Lembrete", body: "" });
+
+  const filteredTemplates = useMemo(() => {
+    if (!search) return templates;
+    const query = search.toLowerCase();
+    return templates.filter((template) =>
+      [template.name, template.body, template.category, template.channel].some((field) =>
+        field.toLowerCase().includes(query)
+      )
+    );
+  }, [search, templates]);
+
+  const reset = () => {
+    setForm({ name: "", channel: channelOptions[0], category: "Lembrete", body: "" });
+    setEditing(null);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const payload: Template = {
+      id: editing ?? `t-${Date.now()}`,
+      name: form.name,
+      channel: form.channel,
+      category: form.category,
+      body: form.body,
+      active: editing ? templates.find((item) => item.id === editing)?.active ?? true : true
+    };
+
+    if (editing) {
+      setTemplates((prev) => prev.map((template) => (template.id === editing ? payload : template)));
+    } else {
+      setTemplates((prev) => [payload, ...prev]);
+    }
+
+    reset();
+  };
+
+  const startEdit = (template: Template) => {
+    setEditing(template.id);
+    setForm({ name: template.name, channel: template.channel, category: template.category, body: template.body });
+  };
+
+  const toggleActive = (id: string) => {
+    setTemplates((prev) =>
+      prev.map((template) => (template.id === id ? { ...template, active: !template.active } : template))
+    );
+  };
+
+  const removeTemplate = (id: string) => {
+    setTemplates((prev) => prev.filter((template) => template.id !== id));
+    if (editing === id) {
+      reset();
+    }
+  };
+
+  const preview = form.body
+    ? form.body.replace(/{{nome}}/gi, "Mariana").replace(/{{horario}}/gi, "15h30")
+    : "Selecione um template ou preencha o conteúdo para visualizar a prévia";
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2">
+        <span className="text-xs uppercase tracking-[0.32em] text-brand">Templates</span>
+        <h1 className="text-3xl font-semibold text-slate-900">Personalize mensagens inteligentes</h1>
+        <p className="text-sm text-slate-500">
+          Ajuste conteúdos e canais de relacionamento para manter uma experiência consistente com a marca.
+        </p>
+      </header>
+
+      <motion.form
+        onSubmit={handleSubmit}
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+      >
+        <div className="grid gap-4 md:grid-cols-4">
+          <label className="md:col-span-2 text-sm font-medium text-slate-600">
+            Nome interno
+            <input
+              required
+              value={form.name}
+              onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-brand focus:outline-none"
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-600">
+            Canal
+            <select
+              value={form.channel}
+              onChange={(event) => setForm((prev) => ({ ...prev, channel: event.target.value as Template["channel"] }))}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-brand focus:outline-none"
+            >
+              {channelOptions.map((channel) => (
+                <option key={channel}>{channel}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm font-medium text-slate-600">
+            Categoria
+            <input
+              value={form.category}
+              onChange={(event) => setForm((prev) => ({ ...prev, category: event.target.value }))}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-brand focus:outline-none"
+            />
+          </label>
+          <label className="md:col-span-4 text-sm font-medium text-slate-600">
+            Conteúdo
+            <textarea
+              required
+              value={form.body}
+              onChange={(event) => setForm((prev) => ({ ...prev, body: event.target.value }))}
+              rows={4}
+              placeholder="Use variáveis como {{nome}} e {{horario}}"
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-brand focus:outline-none"
+            />
+          </label>
+        </div>
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <motion.button
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            type="submit"
+            className="rounded-full bg-brand px-5 py-2 text-sm font-semibold text-white shadow-brand/40"
+          >
+            {editing ? "Atualizar template" : "Adicionar template"}
+          </motion.button>
+          {editing && (
+            <button type="button" onClick={reset} className="text-sm font-medium text-slate-500 underline">
+              Cancelar edição
+            </button>
+          )}
+        </div>
+      </motion.form>
+
+      <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+        <div className="space-y-3">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <h2 className="text-lg font-semibold text-slate-900">Biblioteca ativa</h2>
+            <input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Buscar templates"
+              className="w-full rounded-full border border-slate-200 bg-white px-4 py-2 text-sm focus:border-brand focus:outline-none md:w-72"
+            />
+          </div>
+          <div className="space-y-3">
+            {filteredTemplates.map((template) => (
+              <motion.article
+                key={template.id}
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="rounded-3xl border border-slate-200 bg-white/80 p-5 shadow-sm"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-base font-semibold text-slate-900">{template.name}</p>
+                    <p className="text-xs uppercase tracking-wide text-slate-400">
+                      {template.channel} · {template.category}
+                    </p>
+                  </div>
+                  <div className="flex gap-2 text-xs font-semibold">
+                    <motion.button
+                      whileHover={{ scale: 1.05 }}
+                      whileTap={{ scale: 0.95 }}
+                      onClick={() => toggleActive(template.id)}
+                      className={`rounded-full px-4 py-2 ${
+                        template.active
+                          ? "bg-emerald-100 text-emerald-700"
+                          : "border border-slate-200 text-slate-500"
+                      }`}
+                    >
+                      {template.active ? "Ativo" : "Inativo"}
+                    </motion.button>
+                    <motion.button
+                      whileHover={{ scale: 1.05 }}
+                      whileTap={{ scale: 0.95 }}
+                      onClick={() => startEdit(template)}
+                      className="rounded-full border border-brand px-4 py-2 text-brand"
+                    >
+                      Editar
+                    </motion.button>
+                    <motion.button
+                      whileHover={{ scale: 1.05 }}
+                      whileTap={{ scale: 0.95 }}
+                      onClick={() => removeTemplate(template.id)}
+                      className="rounded-full border border-red-200 px-4 py-2 text-red-500"
+                    >
+                      Excluir
+                    </motion.button>
+                  </div>
+                </div>
+                <p className="mt-3 text-sm text-slate-600">{template.body}</p>
+              </motion.article>
+            ))}
+            {filteredTemplates.length === 0 && (
+              <p className="rounded-3xl border border-dashed border-slate-200 bg-white py-8 text-center text-sm text-slate-400">
+                Nenhum template corresponde a esse filtro.
+              </p>
+            )}
+          </div>
+        </div>
+        <aside className="h-full rounded-3xl border border-slate-200 bg-slate-900/95 p-6 text-white shadow-lg">
+          <h3 className="text-sm uppercase tracking-[0.3em] text-slate-400">Prévia</h3>
+          <p className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-slate-100">{preview}</p>
+          <p className="mt-6 text-xs text-slate-400">
+            Variáveis suportadas: {"{{nome}}"}, {"{{horario}}"}, {"{{servico}}"}, {"{{link_confirmacao}}"}.
+          </p>
+        </aside>
+      </section>
+    </div>
+  );
+}

--- a/sais/web/app/providers.tsx
+++ b/sais/web/app/providers.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { AuthProvider } from "../components/auth-context";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>;
+}

--- a/sais/web/components/auth-context.tsx
+++ b/sais/web/components/auth-context.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+type Role = "owner" | "manager" | "reception" | "dentist";
+
+type User = {
+  name: string;
+  role: Role;
+  permissions: string[];
+};
+
+interface AuthContextValue {
+  user: User;
+  token: string;
+  setRole: (role: Role) => void;
+}
+
+const STORAGE_KEY = "sais.dev.jwt";
+
+const ROLE_CLAIMS: Record<Role, string[]> = {
+  owner: ["view_metrics", "edit_services", "manage_templates", "manage_team"],
+  manager: ["view_metrics", "edit_services", "manage_templates"],
+  reception: ["manage_schedule", "manage_templates"],
+  dentist: ["view_schedule", "update_records"]
+};
+
+const DEFAULT_USER: User = {
+  name: "Clara Andrade",
+  role: "owner",
+  permissions: ROLE_CLAIMS.owner
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+const encode = (value: string) => {
+  if (typeof window !== "undefined" && window.btoa) {
+    return window.btoa(value);
+  }
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value).toString("base64");
+  }
+  return value;
+};
+
+const decode = (value: string) => {
+  if (typeof window !== "undefined" && window.atob) {
+    return window.atob(value);
+  }
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value, "base64").toString("utf-8");
+  }
+  return value;
+};
+
+const buildUser = (role: Role, name?: string): User => ({
+  name: name ?? DEFAULT_USER.name,
+  role,
+  permissions: ROLE_CLAIMS[role]
+});
+
+const decodeToken = (token: string | null): User | null => {
+  if (!token) {
+    return null;
+  }
+  try {
+    const payload = JSON.parse(decode(token));
+    const role = payload.role as Role | undefined;
+    if (!role || !(role in ROLE_CLAIMS)) {
+      return null;
+    }
+    const name = typeof payload.name === "string" ? payload.name : DEFAULT_USER.name;
+    return buildUser(role, name);
+  } catch (error) {
+    console.warn("Falha ao decodificar token de desenvolvimento", error);
+    return null;
+  }
+};
+
+const encodeToken = (user: User) => encode(JSON.stringify({
+  name: user.name,
+  role: user.role,
+  permissions: user.permissions
+}));
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User>(DEFAULT_USER);
+  const [token, setToken] = useState<string>(() => encodeToken(DEFAULT_USER));
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const persisted = window.localStorage.getItem(STORAGE_KEY);
+    const decoded = decodeToken(persisted);
+    if (decoded) {
+      setUser(decoded);
+      setToken(encodeToken(decoded));
+    }
+  }, []);
+
+  const setRole = useCallback((role: Role) => {
+    setUser((prev) => {
+      const nextUser = buildUser(role, prev.name);
+      setToken(encodeToken(nextUser));
+      return nextUser;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, token);
+  }, [token]);
+
+  const value = useMemo<AuthContextValue>(() => ({
+    user,
+    token,
+    setRole
+  }), [setRole, token, user]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth deve ser utilizado dentro de AuthProvider");
+  }
+  return ctx;
+}
+
+export type { Role, User };

--- a/sais/web/components/consent-modal.tsx
+++ b/sais/web/components/consent-modal.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "sais.lgpd.consent";
+
+export function ConsentModal() {
+  const [open, setOpen] = useState(false);
+  const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const persisted = window.localStorage.getItem(STORAGE_KEY);
+    if (!persisted) {
+      const timer = window.setTimeout(() => setOpen(true), 600);
+      return () => window.clearTimeout(timer);
+    }
+  }, []);
+
+  const handleConfirm = () => {
+    if (!checked) return;
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, "accepted");
+    }
+    setOpen(false);
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-6"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            className="max-w-lg rounded-3xl bg-white p-8 shadow-2xl"
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.95, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 220, damping: 24 }}
+          >
+            <h2 className="text-2xl font-semibold text-slate-900">Consentimento LGPD</h2>
+            <p className="mt-4 text-sm text-slate-600">
+              Para enviar lembretes de consulta e confirmações automáticas, precisamos do seu consentimento. Os dados serão
+              usados apenas para comunicação assistida e você pode revogar a qualquer momento.
+            </p>
+            <label className="mt-6 flex items-start gap-3 text-sm text-slate-700">
+              <input
+                type="checkbox"
+                className="mt-1 h-4 w-4 rounded border-slate-300 text-brand focus:ring-brand"
+                checked={checked}
+                onChange={(event) => setChecked(event.target.checked)}
+              />
+              <span>
+                Estou ciente e autorizo o envio de lembretes de consultas via WhatsApp, SMS e e-mail conforme a LGPD.
+              </span>
+            </label>
+            <motion.button
+              whileHover={{ scale: checked ? 1.02 : 1 }}
+              whileTap={{ scale: checked ? 0.98 : 1 }}
+              className="mt-8 w-full rounded-full bg-brand px-5 py-3 text-sm font-semibold text-white shadow-brand/40 transition disabled:cursor-not-allowed disabled:bg-slate-300"
+              onClick={handleConfirm}
+              disabled={!checked}
+            >
+              Confirmar consentimento
+            </motion.button>
+            <p className="mt-4 text-xs text-slate-400">
+              Guardamos apenas as informações essenciais para o relacionamento com a clínica.
+            </p>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/sais/web/components/portal-shell.tsx
+++ b/sais/web/components/portal-shell.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useState } from "react";
+import { motion } from "framer-motion";
+
+import type { Role } from "./auth-context";
+import { useAuth } from "./auth-context";
+import { ConsentModal } from "./consent-modal";
+import { RoleGuard } from "./role-guard";
+
+const navigation: Array<{ label: string; href: string; roles: Role[] }> = [
+  { label: "Dashboard", href: "/portal", roles: ["owner", "manager", "reception", "dentist"] },
+  { label: "Agenda", href: "/portal/agenda", roles: ["owner", "manager", "reception", "dentist"] },
+  { label: "Pacientes", href: "/portal/pacientes", roles: ["owner", "manager", "reception"] },
+  { label: "Serviços", href: "/portal/servicos", roles: ["owner", "manager"] },
+  { label: "Templates", href: "/portal/templates", roles: ["owner", "manager", "reception"] }
+];
+
+const roleOptions: Array<{ value: Role; label: string }> = [
+  { value: "owner", label: "Owner" },
+  { value: "manager", label: "Manager" },
+  { value: "reception", label: "Reception" },
+  { value: "dentist", label: "Dentist" }
+];
+
+export default function PortalShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const { user, setRole, token } = useAuth();
+  const [navOpen, setNavOpen] = useState(false);
+
+  return (
+    <div className="min-h-screen bg-slate-100">
+      <ConsentModal />
+      <header className="border-b border-slate-200 bg-white/80 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-4">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              className="rounded-full border border-slate-200 p-2 text-slate-500 transition hover:border-brand hover:text-brand lg:hidden"
+              onClick={() => setNavOpen((prev) => !prev)}
+              aria-label="Alternar navegação"
+            >
+              <span className="block h-0.5 w-4 bg-current" />
+              <span className="mt-1 block h-0.5 w-4 bg-current" />
+              <span className="mt-1 block h-0.5 w-4 bg-current" />
+            </button>
+            <div>
+              <p className="text-xs uppercase tracking-[0.35em] text-brand">SAIS Portal</p>
+              <h1 className="text-lg font-semibold text-slate-900">Bem-vinda, {user.name}</h1>
+            </div>
+          </div>
+          <div className="flex flex-col items-end gap-1 text-xs text-slate-500">
+            <RoleSwitcher selected={user.role} onChange={setRole} />
+            <span className="max-w-[220px] truncate font-mono" title={token}>
+              {token}
+            </span>
+          </div>
+        </div>
+      </header>
+      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-6 lg:flex-row">
+        <motion.nav
+          layout
+          className={`overflow-hidden rounded-3xl border border-slate-200 bg-white/80 p-4 shadow-sm backdrop-blur transition-all lg:sticky lg:top-6 lg:max-h-[calc(100vh-3rem)] lg:w-64 ${
+            navOpen ? "max-h-96" : "max-h-0 lg:max-h-full"
+          }`}
+        >
+          <ul className="flex flex-col gap-2 text-sm">
+            {navigation.map((item) => (
+              <RoleGuard key={item.href} allowed={item.roles}>
+                <li>
+                  <Link
+                    href={item.href}
+                    className={`flex items-center justify-between rounded-2xl px-4 py-3 transition ${
+                      pathname === item.href
+                        ? "bg-brand text-white shadow-brand/30"
+                        : "text-slate-600 hover:bg-slate-100"
+                    }`}
+                    onClick={() => setNavOpen(false)}
+                  >
+                    {item.label}
+                    <span aria-hidden>›</span>
+                  </Link>
+                </li>
+              </RoleGuard>
+            ))}
+          </ul>
+        </motion.nav>
+        <main className="flex-1 space-y-8 pb-12">{children}</main>
+      </div>
+    </div>
+  );
+}
+
+function RoleSwitcher({ selected, onChange }: { selected: Role; onChange: (role: Role) => void }) {
+  return (
+    <label className="flex flex-col items-end gap-1 text-xs font-medium text-slate-500">
+      Perfil ativo
+      <motion.select
+        whileFocus={{ scale: 1.02 }}
+        className="rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 shadow-sm focus:border-brand focus:outline-none"
+        value={selected}
+        onChange={(event) => onChange(event.target.value as Role)}
+      >
+        {roleOptions.map((role) => (
+          <option key={role.value} value={role.value}>
+            {role.label}
+          </option>
+        ))}
+      </motion.select>
+    </label>
+  );
+}

--- a/sais/web/components/role-guard.tsx
+++ b/sais/web/components/role-guard.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import type { Role } from "./auth-context";
+import { useAuth } from "./auth-context";
+
+interface RoleGuardProps {
+  allowed: Role[];
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+export function RoleGuard({ allowed, children, fallback }: RoleGuardProps) {
+  const { user } = useAuth();
+
+  if (!allowed.includes(user.role)) {
+    return fallback ?? null;
+  }
+
+  return <>{children}</>;
+}

--- a/sais/web/components/schedule-board.tsx
+++ b/sais/web/components/schedule-board.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { DndContext, DragEndEvent, PointerSensor, useDroppable, useSensor, useSensors } from "@dnd-kit/core";
+import { restrictToParentElement } from "@dnd-kit/modifiers";
+import { SortableContext, verticalListSortingStrategy, useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { motion } from "framer-motion";
+import { type CSSProperties, useMemo, useState } from "react";
+
+import { RoleGuard } from "./role-guard";
+
+interface Appointment {
+  id: string;
+  patient: string;
+  provider: string;
+  service: string;
+  start: string;
+  duration: number;
+  status: "confirmado" | "pendente" | "retorno";
+}
+
+type DayKey = "monday" | "tuesday" | "wednesday" | "thursday" | "friday";
+
+type ScheduleState = Record<DayKey, Appointment[]>;
+
+const weekDays: Array<{ key: DayKey; label: string; date: string }> = [
+  { key: "monday", label: "Seg", date: "15/04" },
+  { key: "tuesday", label: "Ter", date: "16/04" },
+  { key: "wednesday", label: "Qua", date: "17/04" },
+  { key: "thursday", label: "Qui", date: "18/04" },
+  { key: "friday", label: "Sex", date: "19/04" }
+];
+
+const providers = [
+  { id: "sofia", name: "Dra. Sofia Lima" },
+  { id: "caio", name: "Dr. Caio Moura" },
+  { id: "aline", name: "Dra. Aline Costa" }
+];
+
+const services = [
+  { id: "avaliacao", name: "Avaliação" },
+  { id: "limpeza", name: "Limpeza" },
+  { id: "lente", name: "Lente de contato" },
+  { id: "clareamento", name: "Clareamento" }
+];
+
+const initialSchedule: ScheduleState = {
+  monday: [
+    {
+      id: "a-1",
+      patient: "João Nogueira",
+      provider: "sofia",
+      service: "avaliacao",
+      start: "09:00",
+      duration: 60,
+      status: "confirmado"
+    },
+    {
+      id: "a-2",
+      patient: "Ana Paula",
+      provider: "caio",
+      service: "limpeza",
+      start: "10:30",
+      duration: 50,
+      status: "pendente"
+    }
+  ],
+  tuesday: [
+    {
+      id: "a-3",
+      patient: "Carla Ribeiro",
+      provider: "aline",
+      service: "lente",
+      start: "09:30",
+      duration: 90,
+      status: "confirmado"
+    },
+    {
+      id: "a-4",
+      patient: "Marcos Dias",
+      provider: "sofia",
+      service: "avaliacao",
+      start: "15:00",
+      duration: 45,
+      status: "retorno"
+    }
+  ],
+  wednesday: [
+    {
+      id: "a-5",
+      patient: "Vitória Martins",
+      provider: "caio",
+      service: "clareamento",
+      start: "11:00",
+      duration: 80,
+      status: "pendente"
+    }
+  ],
+  thursday: [
+    {
+      id: "a-6",
+      patient: "Lucas Ferreira",
+      provider: "aline",
+      service: "limpeza",
+      start: "14:00",
+      duration: 50,
+      status: "confirmado"
+    },
+    {
+      id: "a-7",
+      patient: "Paula Rocha",
+      provider: "caio",
+      service: "avaliacao",
+      start: "16:30",
+      duration: 40,
+      status: "retorno"
+    }
+  ],
+  friday: [
+    {
+      id: "a-8",
+      patient: "Eduardo Silva",
+      provider: "sofia",
+      service: "clareamento",
+      start: "09:00",
+      duration: 100,
+      status: "confirmado"
+    }
+  ]
+};
+
+const statusStyles: Record<Appointment["status"], string> = {
+  confirmado: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  pendente: "bg-amber-100 text-amber-700 border-amber-200",
+  retorno: "bg-indigo-100 text-indigo-700 border-indigo-200"
+};
+
+export function ScheduleBoard() {
+  const [schedule, setSchedule] = useState<ScheduleState>(initialSchedule);
+  const [providerFilter, setProviderFilter] = useState<string>("all");
+  const [serviceFilter, setServiceFilter] = useState<string>("all");
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+
+  const filteredSchedule = useMemo(() => {
+    if (providerFilter === "all" && serviceFilter === "all") {
+      return schedule;
+    }
+
+    const filteredEntries = Object.entries(schedule).map(([day, items]) => [
+      day,
+      items.filter((appointment) => {
+        const matchesProvider = providerFilter === "all" || appointment.provider === providerFilter;
+        const matchesService = serviceFilter === "all" || appointment.service === serviceFilter;
+        return matchesProvider && matchesService;
+      })
+    ]);
+
+    return Object.fromEntries(filteredEntries) as ScheduleState;
+  }, [providerFilter, schedule, serviceFilter]);
+
+  const findDayByAppointment = (id: string): DayKey | undefined => {
+    return weekDays.find(({ key }) => schedule[key].some((item) => item.id === id))?.key;
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+
+    const fromDay = findDayByAppointment(active.id as string);
+    if (!fromDay) return;
+
+    let toDay = weekDays.find((day) => day.key === over.id)?.key;
+    if (!toDay) {
+      toDay = findDayByAppointment(over.id as string);
+    }
+    if (!toDay) return;
+
+    setSchedule((prev) => {
+      const sourceItems = [...prev[fromDay]];
+      const movingIndex = sourceItems.findIndex((item) => item.id === active.id);
+      if (movingIndex < 0) return prev;
+      const [moving] = sourceItems.splice(movingIndex, 1);
+      const nextState: ScheduleState = { ...prev, [fromDay]: sourceItems };
+
+      const destinationItems = [...nextState[toDay]];
+      const overIndex = destinationItems.findIndex((item) => item.id === over.id);
+      if (overIndex >= 0) {
+        destinationItems.splice(overIndex, 0, moving);
+      } else {
+        destinationItems.push(moving);
+      }
+      nextState[toDay] = destinationItems;
+      return nextState;
+    });
+  };
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-900">Agenda semanal</h1>
+          <p className="text-sm text-slate-500">Arraste para reagendar e mantenha a equipe sincronizada em tempo real.</p>
+        </div>
+        <div className="flex flex-wrap gap-3 text-sm">
+          <label className="flex items-center gap-2">
+            Profissional
+            <select
+              value={providerFilter}
+              onChange={(event) => setProviderFilter(event.target.value)}
+              className="rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-medium text-slate-600 shadow-sm focus:border-brand"
+            >
+              <option value="all">Todos</option>
+              {providers.map((provider) => (
+                <option key={provider.id} value={provider.id}>
+                  {provider.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-2">
+            Procedimento
+            <select
+              value={serviceFilter}
+              onChange={(event) => setServiceFilter(event.target.value)}
+              className="rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-medium text-slate-600 shadow-sm focus:border-brand"
+            >
+              <option value="all">Todos</option>
+              {services.map((service) => (
+                <option key={service.id} value={service.id}>
+                  {service.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </header>
+      <DndContext sensors={sensors} onDragEnd={handleDragEnd} modifiers={[restrictToParentElement]}>
+        <div className="grid gap-4 md:grid-cols-5">
+          {weekDays.map((day) => (
+            <DayColumn key={day.key} day={day} appointments={filteredSchedule[day.key]} />
+          ))}
+        </div>
+      </DndContext>
+      <RoleGuard
+        allowed={["owner", "manager", "reception"]}
+        fallback={
+          <p className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+            Dentistas conseguem apenas visualizar a agenda. Para reagendar, altere o perfil para recepção.
+          </p>
+        }
+      >
+        <p className="text-xs text-slate-400">
+          Toda movimentação gera rastreabilidade automática em tempo real e notifica pacientes conforme preferências de canal.
+        </p>
+      </RoleGuard>
+    </section>
+  );
+}
+
+function DayColumn({
+  day,
+  appointments
+}: {
+  day: (typeof weekDays)[number];
+  appointments: Appointment[];
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: day.key });
+
+  return (
+    <SortableContext items={appointments.map((appointment) => appointment.id)} strategy={verticalListSortingStrategy}>
+      <div
+        ref={setNodeRef}
+        className={`flex min-h-[240px] flex-col gap-3 rounded-3xl border border-slate-200 bg-white/60 p-4 backdrop-blur transition ${
+          isOver ? "ring-2 ring-brand/40" : ""
+        }`}
+        data-day={day.key}
+      >
+        <div className="flex items-baseline justify-between text-sm text-slate-500">
+          <span className="font-semibold text-slate-700">{day.label}</span>
+          <span>{day.date}</span>
+        </div>
+        {appointments.map((appointment) => (
+          <ScheduleCard key={appointment.id} appointment={appointment} />
+        ))}
+        {appointments.length === 0 && (
+          <p className="rounded-2xl border border-dashed border-slate-200 bg-white px-3 py-6 text-center text-xs text-slate-400">
+            Sem consultas — arraste um paciente para cá
+          </p>
+        )}
+      </div>
+    </SortableContext>
+  );
+}
+
+function ScheduleCard({ appointment }: { appointment: Appointment }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: appointment.id
+  });
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 10 : "auto"
+  };
+
+  const provider = providers.find((item) => item.id === appointment.provider)?.name ?? appointment.provider;
+  const service = services.find((item) => item.id === appointment.service)?.name ?? appointment.service;
+
+  return (
+    <motion.article
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      whileHover={{ scale: 1.01 }}
+      whileTap={{ scale: 0.99 }}
+      className={`cursor-grab rounded-2xl border p-4 shadow-sm ${statusStyles[appointment.status]}`}
+    >
+      <header className="flex items-start justify-between text-xs uppercase tracking-wide">
+        <span>{appointment.start}</span>
+        <span>{appointment.duration}min</span>
+      </header>
+      <h3 className="mt-2 text-sm font-semibold">{appointment.patient}</h3>
+      <p className="mt-1 text-xs text-slate-600">{service}</p>
+      <p className="mt-1 text-xs text-slate-500">{provider}</p>
+      <span className="mt-3 inline-flex items-center rounded-full bg-white/70 px-3 py-1 text-[11px] font-semibold text-slate-700">
+        {appointment.status === "confirmado" && "Confirmado"}
+        {appointment.status === "pendente" && "Aguardando"}
+        {appointment.status === "retorno" && "Retorno"}
+      </span>
+    </motion.article>
+  );
+}

--- a/sais/web/next-env.d.ts
+++ b/sais/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/sais/web/next.config.mjs
+++ b/sais/web/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/sais/web/package-lock.json
+++ b/sais/web/package-lock.json
@@ -1,0 +1,6159 @@
+{
+  "name": "sais-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sais-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "@dnd-kit/core": "^6.0.8",
+        "@dnd-kit/modifiers": "^6.0.1",
+        "@dnd-kit/sortable": "^7.0.2",
+        "framer-motion": "^11.0.0",
+        "next": "14.1.0",
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
+      },
+      "devDependencies": {
+        "@types/node": "20.11.30",
+        "@types/react": "18.2.47",
+        "@types/react-dom": "18.2.18",
+        "autoprefixer": "10.4.17",
+        "eslint": "8.57.0",
+        "eslint-config-next": "14.1.0",
+        "postcss": "8.4.35",
+        "tailwindcss": "3.4.1",
+        "typescript": "5.4.5"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-6.0.1.tgz",
+      "integrity": "sha512-rbxcsg3HhzlcMHVHWDuh9LCjpOVAgqbV78wLGI8tziXY3+qcMQ61qVXIvNKQFuhj75dSfD+o+PYZQ/NUk2A23A==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.1",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.0.6",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-7.0.2.tgz",
+      "integrity": "sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.0.7",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.0.tgz",
+      "integrity": "sha512-Py8zIo+02ht82brwwhTg36iogzFqGLPXlRGKQw5s+qP/kMNc4MAyDeEwBKDijk6zTIbegEgu8Qy7C1LboslQAw==",
+      "license": "MIT"
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.1.0.tgz",
+      "integrity": "sha512-x4FavbNEeXx/baD/zC/SdrvkjSby8nBn8KcCREqk6UuwvwoAPZmaV8TFCAuo/cpovBRTIY67mHhe86MQQm/68Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "10.3.10"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.0.tgz",
+      "integrity": "sha512-nUDn7TOGcIeyQni6lZHfzNoo9S0euXnu0jhsbMOmMJUBfgsnESdjN97kM7cBqQxZa8L/bM9om/S5/1dzCrW6wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.0.tgz",
+      "integrity": "sha512-1jgudN5haWxiAl3O1ljUS2GfupPmcftu2RYJqZiMJmmbBT5M1XDffjUtRUzP4W3cBHsrvkfOFdQ71hAreNQP6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.0.tgz",
+      "integrity": "sha512-RHo7Tcj+jllXUbK7xk2NyIDod3YcCPDZxj1WLIYxd709BQ7WuRYl3OWUNG+WUfqeQBds6kvZYlc42NJJTNi4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.0.tgz",
+      "integrity": "sha512-v6kP8sHYxjO8RwHmWMJSq7VZP2nYCkRVQ0qolh2l6xroe9QjbgV8siTbduED4u0hlk0+tjS6/Tuy4n5XCp+l6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.0.tgz",
+      "integrity": "sha512-zJ2pnoFYB1F4vmEVlb/eSe+VH679zT1VdXlZKX+pE66grOgjmKJHKacf82g/sWE4MQ4Rk2FMBCRnX+l6/TVYzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.0.tgz",
+      "integrity": "sha512-rbaIYFt2X9YZBSbH/CwGAjbBG2/MrACCVu2X0+kSykHzHnYH5FjHxwXLkcoJ10cX0aWCEynpu+rP76x0914atg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.0.tgz",
+      "integrity": "sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.0.tgz",
+      "integrity": "sha512-XXIuB1DBRCFwNO6EEzCTMHT5pauwaSj4SWs7CYnME57eaReAKBXCnkUE80p/pAZcewm7hs+vGvNqDPacEXHVkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.0.tgz",
+      "integrity": "sha512-9WEbVRRAqJ3YFVqEZIxUqkiO8l1nool1LmNxygr5HWF8AcSYsEpneUDhmjUVJEzO2A04+oPtZdombzzPPkTtgg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rushstack/eslint-patch": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
+      "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.47",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.47.tgz",
+      "integrity": "sha512-xquNkkOirwyCgoClNk85BjP+aqnIS+ckAJ8i37gAbDs14jfW/J23f2GItAf33oiUPQnqNMALiFeoM9Y5mbjpVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.18.tgz",
+      "integrity": "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.17",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
+      "integrity": "sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.22.2",
+        "caniuse-lite": "^1.0.30001578",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.4.tgz",
+      "integrity": "sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
+      "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.3",
+        "caniuse-lite": "^1.0.30001741",
+        "electron-to-chromium": "^1.5.218",
+        "node-releases": "^2.0.21",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001743",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
+      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.218",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.218.tgz",
+      "integrity": "sha512-uwwdN0TUHs8u6iRgN8vKeWZMRll4gBkz+QMqdS7DDe49uiK68/UX92lFb61oiFPrpYZNeZIqa4bA7O6Aiasnzg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
+      "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.0.3",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.6",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.4",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-next": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.1.0.tgz",
+      "integrity": "sha512-SBX2ed7DoRFXC6CQSLc/SbLY9Ut6HxNB2wPTcoIWjUMd7aF7O/SIE7111L8FdZ9TXsNV4pulUDnfthpyPtbFUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "14.1.0",
+        "@rushstack/eslint-patch": "^1.3.3",
+        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.28.1",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-react": "^7.33.2",
+        "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
+      },
+      "peerDependencies": {
+        "eslint": "^7.23.0 || ^8.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.0.0-canary-7118f5dd7-20230705",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0-canary-7118f5dd7-20230705.tgz",
+      "integrity": "sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.3.tgz",
+      "integrity": "sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/next": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.1.0.tgz",
+      "integrity": "sha512-wlzrsbfeSU48YQBjZhDzOwhWhGsy+uQycR8bHAOt1LY1bn3zZEcDyHQOEoN3aWzQ8LHCAJ1nqrWCc9XF2+O45Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.1.0",
+        "@swc/helpers": "0.5.2",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.1.0",
+        "@next/swc-darwin-x64": "14.1.0",
+        "@next/swc-linux-arm64-gnu": "14.1.0",
+        "@next/swc-linux-arm64-musl": "14.1.0",
+        "@next/swc-linux-x64-gnu": "14.1.0",
+        "@next/swc-linux-x64-musl": "14.1.0",
+        "@next/swc-win32-arm64-msvc": "14.1.0",
+        "@next/swc-win32-ia32-msvc": "14.1.0",
+        "@next/swc-win32-x64-msvc": "14.1.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+      "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
+      "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.5.3",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.0",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.19.1",
+        "lilconfig": "^2.1.0",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.23",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.1",
+        "postcss-nested": "^6.0.1",
+        "postcss-selector-parser": "^6.0.11",
+        "resolve": "^1.22.2",
+        "sucrase": "^3.32.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-load-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-load-config/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/sais/web/package.json
+++ b/sais/web/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "sais-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/modifiers": "^6.0.1",
+    "@dnd-kit/sortable": "^7.0.2",
+    "framer-motion": "^11.0.0",
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.30",
+    "@types/react": "18.2.47",
+    "@types/react-dom": "18.2.18",
+    "autoprefixer": "10.4.17",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.1.0",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.4.5"
+  }
+}

--- a/sais/web/postcss.config.js
+++ b/sais/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/sais/web/tailwind.config.ts
+++ b/sais/web/tailwind.config.ts
@@ -1,0 +1,23 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+    "./pages/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: "#2563eb",
+          dark: "#1d4ed8",
+          light: "#93c5fd"
+        }
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/sais/web/tsconfig.json
+++ b/sais/web/tsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": [
+      "node"
+    ],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.cjs",
+    "**/*.mjs",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- instrument the FastAPI service with structured logging utilities, contextual middleware, rate limiting, and Prometheus metrics while renaming message metadata fields to avoid SQLAlchemy conflicts
- add a reusable seed script and Makefile target to populate demo tenants, services, providers, patients, and schedule slots with updated environment defaults for CORS and rate limiting
- expand CI to run pytest, build docker images, validate docker compose, and add regression tests covering health and metrics endpoints

## Testing
- python -m compileall api/app jobs/app
- pytest
- npm run lint --prefix web

------
https://chatgpt.com/codex/tasks/task_e_68c9a0e3ea208321bb49eebba2a3eae9