### PR TITLE
Replace raster placeholders with SVG assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Samuel Pessoal
+
+Este projeto contém uma página estática simples para divulgar informações pessoais ou profissionais. As imagens utilizadas são vetores
+mínimos criados como placeholders, o que facilita a visualização dos diffs e a customização.
+
+## Estrutura
+
+```
+assets/
+└── img/
+    ├── hero-placeholder.svg
+    ├── profile-placeholder.svg
+    └── project-placeholder.svg
+index.html
+README.md
+```
+
+### Imagens vetoriais
+
+Todas as imagens em `assets/img/` estão no formato SVG. Elas foram desenhadas com gradientes suaves e texto explicando o conteúdo que deve ser
+substituído. Como são vetoriais, você pode editá-las diretamente em um editor de texto ou em ferramentas como Figma, Illustrator e Inkscape
+antes de exportar suas versões definitivas.
+
+Para atualizar uma imagem:
+
+1. Substitua o arquivo `.svg` correspondente por outro com o mesmo nome.
+2. Caso prefira usar um formato raster (PNG, JPG, WEBP), mantenha a mesma nomenclatura mas atualize o caminho em `index.html` para o novo arquivo.
+3. Ajuste os atributos `width`, `height` e `alt` da tag `<img>` conforme necessário para refletir o novo conteúdo.
+
+### Desenvolvimento
+
+Nenhuma ferramenta específica é necessária: basta abrir `index.html` em um navegador para visualizar o resultado. Se desejar publicar a página, é
+possível fazer o deploy em serviços estáticos como GitHub Pages, Netlify ou Vercel.

--- a/assets/img/hero-placeholder.svg
+++ b/assets/img/hero-placeholder.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 400" role="img" aria-labelledby="heroTitle heroDesc">
+  <title id="heroTitle">Hero placeholder</title>
+  <desc id="heroDesc">Gradient background with centered title text</desc>
+  <defs>
+    <linearGradient id="heroGradient" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#2c61f0" />
+      <stop offset="100%" stop-color="#7d4fff" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="400" fill="url(#heroGradient)" rx="24" />
+  <text x="50%" y="52%" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="64" font-weight="600" fill="#ffffff" letter-spacing="4">Hero Placeholder</text>
+  <text x="50%" y="67%" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="24" fill="#f2f4ff">Replace with a hero image</text>
+</svg>

--- a/assets/img/profile-placeholder.svg
+++ b/assets/img/profile-placeholder.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" role="img" aria-labelledby="profileTitle profileDesc">
+  <title id="profileTitle">Profile placeholder</title>
+  <desc id="profileDesc">Circular gradient avatar with initials</desc>
+  <defs>
+    <radialGradient id="profileGradient" cx="50%" cy="45%" r="70%">
+      <stop offset="0%" stop-color="#ffda8f" />
+      <stop offset="100%" stop-color="#ff7a7a" />
+    </radialGradient>
+  </defs>
+  <rect width="400" height="400" rx="48" fill="#f6f6f9" />
+  <circle cx="200" cy="180" r="120" fill="url(#profileGradient)" />
+  <text x="50%" y="195" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="96" font-weight="700" fill="#ffffff">AB</text>
+  <text x="50%" y="310" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="28" fill="#5a5f7a">Profile Image</text>
+</svg>

--- a/assets/img/project-placeholder.svg
+++ b/assets/img/project-placeholder.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 400" role="img" aria-labelledby="projectTitle projectDesc">
+  <title id="projectTitle">Project preview placeholder</title>
+  <desc id="projectDesc">Abstract grid with project label text</desc>
+  <defs>
+    <linearGradient id="projectGradient" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#1cb5e0" />
+      <stop offset="100%" stop-color="#000851" />
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="rgba(255,255,255,0.12)" stroke-width="2" />
+    </pattern>
+  </defs>
+  <rect width="640" height="400" rx="32" fill="url(#projectGradient)" />
+  <rect width="640" height="400" rx="32" fill="url(#grid)" />
+  <text x="50%" y="50%" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="48" font-weight="600" fill="#ffffff">Project Snapshot</text>
+  <text x="50%" y="65%" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="22" fill="#d4f3ff">Swap this with your project art</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Samuel Pessoal</title>
+    <link rel="preload" href="assets/img/hero-placeholder.svg" as="image" type="image/svg+xml" />
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: 'Segoe UI', Roboto, Arial, sans-serif;
+        line-height: 1.5;
+        background-color: #f6f8fb;
+        color: #202336;
+      }
+      body {
+        margin: 0;
+      }
+      header {
+        padding: 6rem 1.5rem 3rem;
+        max-width: 960px;
+        margin: 0 auto;
+        text-align: center;
+      }
+      header img {
+        display: block;
+        width: min(100%, 960px);
+        height: auto;
+        margin: 0 auto 2.5rem;
+      }
+      main {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 0 1.5rem 4rem;
+        display: grid;
+        gap: 3rem;
+      }
+      .profile {
+        display: grid;
+        grid-template-columns: minmax(180px, 240px) 1fr;
+        gap: 2rem;
+        align-items: center;
+      }
+      .profile img {
+        width: 100%;
+        height: auto;
+      }
+      .projects {
+        display: grid;
+        gap: 2rem;
+      }
+      .projects img {
+        width: 100%;
+        height: auto;
+        border-radius: 1.5rem;
+        box-shadow: 0 12px 32px rgba(24, 36, 78, 0.18);
+      }
+      footer {
+        text-align: center;
+        padding: 3rem 1.5rem;
+        color: #5a5f7a;
+      }
+      @media (max-width: 720px) {
+        header {
+          padding-top: 3rem;
+        }
+        .profile {
+          grid-template-columns: 1fr;
+          text-align: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <img
+        src="assets/img/hero-placeholder.svg"
+        width="1200"
+        height="400"
+        alt="Plano de fundo gradiente com texto indicando onde a imagem principal deve ser trocada"
+      />
+      <h1>Olá, eu sou Samuel</h1>
+      <p>Este site pessoal está em construção. Substitua as imagens abaixo pelos seus próprios materiais visuais.</p>
+    </header>
+    <main>
+      <section class="profile">
+        <img
+          src="assets/img/profile-placeholder.svg"
+          width="400"
+          height="400"
+          alt="Avatar ilustrativo com fundo gradiente e as iniciais AB"
+        />
+        <div>
+          <h2>Sobre mim</h2>
+          <p>
+            Use esta seção para apresentar um resumo da sua trajetória, especialidades e objetivos. Enquanto isso, a imagem ao lado serve
+            apenas como lembrete visual e pode ser substituída por uma foto profissional.
+          </p>
+        </div>
+      </section>
+      <section class="projects">
+        <h2>Projetos em destaque</h2>
+        <img
+          src="assets/img/project-placeholder.svg"
+          width="640"
+          height="400"
+          alt="Miniatura abstrata com grade e texto indicando a troca pela imagem do projeto"
+        />
+        <p>
+          Troque este arquivo vetorial por um print do seu projeto ou uma composição que represente o trabalho. Como o formato é SVG, você pode
+          exportar de ferramentas vetoriais ou simplesmente substituir a referência pelo seu próprio arquivo.
+        </p>
+      </section>
+    </main>
+    <footer>© 2024 Samuel Pessoal • Atualize este rodapé com seus contatos.</footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add gradient-based SVG placeholders for hero, profile and project images
- update the landing page to load the SVG assets with accessible dimensions and descriptions
- revise the README with guidance on updating the vector images

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dac05dc4fc832199552d1c9ba1d008